### PR TITLE
Switch from hashicorp to opentofu provider namespace

### DIFF
--- a/tfexec/internal/e2etest/graph_test.go
+++ b/tfexec/internal/e2etest/graph_test.go
@@ -84,12 +84,12 @@ func expectedGraphOutput(tfv *version.Version) string {
 	newrank = "true"
 	subgraph "root" {
 		"[root] null_resource.foo (expand)" [label = "null_resource.foo", shape = "box"]
-		"[root] provider[\"registry.opentofu.org/hashicorp/null\"]" [label = "provider[\"registry.opentofu.org/hashicorp/null\"]", shape = "diamond"]
+		"[root] provider[\"registry.opentofu.org/opentofu/null\"]" [label = "provider[\"registry.opentofu.org/opentofu/null\"]", shape = "diamond"]
 		"[root] meta.count-boundary (EachMode fixup)" -> "[root] null_resource.foo (expand)"
-		"[root] null_resource.foo (expand)" -> "[root] provider[\"registry.opentofu.org/hashicorp/null\"]"
-		"[root] provider[\"registry.opentofu.org/hashicorp/null\"] (close)" -> "[root] null_resource.foo (expand)"
+		"[root] null_resource.foo (expand)" -> "[root] provider[\"registry.opentofu.org/opentofu/null\"]"
+		"[root] provider[\"registry.opentofu.org/opentofu/null\"] (close)" -> "[root] null_resource.foo (expand)"
 		"[root] root" -> "[root] meta.count-boundary (EachMode fixup)"
-		"[root] root" -> "[root] provider[\"registry.opentofu.org/hashicorp/null\"] (close)"
+		"[root] root" -> "[root] provider[\"registry.opentofu.org/opentofu/null\"] (close)"
 	}
 }
 
@@ -102,10 +102,10 @@ func expectedGraphOutput(tfv *version.Version) string {
 	newrank = "true"
 	subgraph "root" {
 		"[root] null_resource.foo (expand)" [label = "null_resource.foo", shape = "box"]
-		"[root] provider[\"registry.opentofu.org/hashicorp/null\"]" [label = "provider[\"registry.opentofu.org/hashicorp/null\"]", shape = "diamond"]
-		"[root] null_resource.foo (expand)" -> "[root] provider[\"registry.opentofu.org/hashicorp/null\"]"
-		"[root] provider[\"registry.opentofu.org/hashicorp/null\"] (close)" -> "[root] null_resource.foo (expand)"
-		"[root] root" -> "[root] provider[\"registry.opentofu.org/hashicorp/null\"] (close)"
+		"[root] provider[\"registry.opentofu.org/opentofu/null\"]" [label = "provider[\"registry.opentofu.org/opentofu/null\"]", shape = "diamond"]
+		"[root] null_resource.foo (expand)" -> "[root] provider[\"registry.opentofu.org/opentofu/null\"]"
+		"[root] provider[\"registry.opentofu.org/opentofu/null\"] (close)" -> "[root] null_resource.foo (expand)"
+		"[root] root" -> "[root] provider[\"registry.opentofu.org/opentofu/null\"] (close)"
 	}
 }
 

--- a/tfexec/internal/e2etest/providers_schema_test.go
+++ b/tfexec/internal/e2etest/providers_schema_test.go
@@ -88,7 +88,7 @@ func TestProvidersSchema(t *testing.T) {
 									"random": {
 										AttributeType: cty.String,
 										Computed:      true,
-										Description:   "A random value. This is primarily for testing and has little practical use; prefer the [hashicorp/random provider](https://registry.opentofu.org/providers/hashicorp/random) for more practical random number use-cases.",
+										Description:   "A random value. This is primarily for testing and has little practical use; prefer the [opentofu/random provider](https://registry.opentofu.org/providers/opentofu/random) for more practical random number use-cases.",
 									},
 								},
 							},
@@ -100,7 +100,7 @@ func TestProvidersSchema(t *testing.T) {
 				providerAddr := "null"
 
 				if tfv.Core().GreaterThanOrEqual(v0_13_0) {
-					providerAddr = "registry.opentofu.org/hashicorp/null"
+					providerAddr = "registry.opentofu.org/opentofu/null"
 
 					nullSchema = &tfjson.ProviderSchema{
 						ConfigSchema: &tfjson.Schema{

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -32,7 +32,7 @@ func TestShow(t *testing.T) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}
 
-		providerName := "registry.opentofu.org/hashicorp/null"
+		providerName := "registry.opentofu.org/opentofu/null"
 		if tfv.LessThan(providerAddressMinVersion) {
 			providerName = "null"
 		}
@@ -354,7 +354,7 @@ func TestShowStateFile013(t *testing.T) {
 						Mode:         tfjson.ManagedResourceMode,
 						Type:         "null_resource",
 						Name:         "foo",
-						ProviderName: "registry.opentofu.org/hashicorp/null",
+						ProviderName: "registry.opentofu.org/opentofu/null",
 					}},
 				},
 			},
@@ -392,7 +392,7 @@ func TestShowStateFile014(t *testing.T) {
 						Mode:         tfjson.ManagedResourceMode,
 						Type:         "null_resource",
 						Name:         "foo",
-						ProviderName: "registry.opentofu.org/hashicorp/null",
+						ProviderName: "registry.opentofu.org/opentofu/null",
 					}},
 				},
 			},
@@ -484,7 +484,7 @@ func TestShowPlanFile012_linux(t *testing.T) {
 
 func TestShowPlanFile013(t *testing.T) {
 	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
-		providerName := "registry.opentofu.org/hashicorp/null"
+		providerName := "registry.opentofu.org/opentofu/null"
 
 		expected := &tfjson.Plan{
 			// TerraformVersion is ignored to facilitate latsest version testing
@@ -546,7 +546,7 @@ func TestShowPlanFile013(t *testing.T) {
 
 func TestShowPlanFile014(t *testing.T) {
 	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
-		providerName := "registry.opentofu.org/hashicorp/null"
+		providerName := "registry.opentofu.org/opentofu/null"
 
 		expected := &tfjson.Plan{
 			// TerraformVersion is ignored to facilitate latsest version testing
@@ -702,7 +702,7 @@ func TestShowBigInt(t *testing.T) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
 
-		providerName := "registry.opentofu.org/hashicorp/random"
+		providerName := "registry.opentofu.org/opentofu/random"
 		if tfv.LessThan(providerAddressMinVersion) {
 			providerName = "random"
 		}

--- a/tfexec/internal/e2etest/state_mv_test.go
+++ b/tfexec/internal/e2etest/state_mv_test.go
@@ -20,7 +20,7 @@ func TestStateMv(t *testing.T) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}
 
-		providerName := "registry.opentofu.org/hashicorp/null"
+		providerName := "registry.opentofu.org/opentofu/null"
 
 		err := tf.Init(context.Background())
 		if err != nil {

--- a/tfexec/internal/e2etest/testdata/basic_with_state/terraform.tfstate
+++ b/tfexec/internal/e2etest/testdata/basic_with_state/terraform.tfstate
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "foo",
-      "provider": "provider[\"registry.opentofu.org/hashicorp/null\"]",
+      "provider": "provider[\"registry.opentofu.org/opentofu/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/tfexec/internal/e2etest/testdata/non_default_statefile_013/statefilefoo
+++ b/tfexec/internal/e2etest/testdata/non_default_statefile_013/statefilefoo
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "foo",
-      "provider": "provider[\"registry.opentofu.org/hashicorp/null\"]",
+      "provider": "provider[\"registry.opentofu.org/opentofu/null\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/tfexec/internal/e2etest/testdata/non_default_statefile_014/statefilefoo
+++ b/tfexec/internal/e2etest/testdata/non_default_statefile_014/statefilefoo
@@ -9,7 +9,7 @@
       "mode": "managed",
       "type": "null_resource",
       "name": "foo",
-      "provider": "provider[\"registry.opentofu.org/hashicorp/null\"]",
+      "provider": "provider[\"registry.opentofu.org/opentofu/null\"]",
       "instances": [
         {
           "schema_version": 0,


### PR DESCRIPTION
```
go test -race -timeout=30m -v ./tfexec/internal/e2etest 
...
PASS
ok      github.com/hashicorp/terraform-exec/tfexec/internal/e2etest     55.526s
```