### PR TITLE
Changes terraform-exec to tofu-exec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,18 @@
-# Contributing to terraform-exec
+# This repository is a work in progress
 
-While terraform-exec is already widely used, please note that this module is **not yet at v1.0.0**, and that therefore breaking changes may occur in minor releases.
+This repository is currently not usable and requires a large set of changes to make it so.
+We are going to update this repository solely to use it in [`tofu-ls`](https://github.com/opentofu/tofu-ls).
+This document will be updated as part of those changes. We do not recommend using this library outside of `tofu-ls`. [Link to the Issue](https://github.com/opentofu/opentofu/issues/2455#issuecomment-2858320418)
 
-We strictly follow [semantic versioning](https://semver.org).
+# Contributing to tofu-exec
 
 ## Repository structure
 
-Three packages comprise the public API of the terraform-exec Go module:
+Three packages comprise the public API of the tofu-exec Go module:
 
 ### `tfexec`
 
-Package `github.com/hashicorp/terraform-exec/tfexec` exposes functionality for constructing and running Terraform CLI commands. Structured return values use the data types defined in the [hashicorp/terraform-json](https://github.com/hashicorp/terraform-json) package.
+Package `github.com/opentofu/tofu-exec/tfexec` exposes functionality for constructing and running Terraform CLI commands. Structured return values use the data types defined in the [hashicorp/terraform-json](https://github.com/hashicorp/terraform-json) package.
 
 #### Adding a new Terraform CLI command to `tfexec`
 
@@ -65,17 +67,17 @@ Subject to [compatibility guarantees](https://www.terraform.io/language/v1-compa
  - Change stdout or stderr output
  - Change the format of output files, e.g. the state file
  - Change a command's exit code
- 
+
 These and any other differences between versions should be specified in test assertions.
 
 If the command implemented differs in any way between Terraform versions (e.g. a flag is added or removed, or the subcommand does not exist in earlier versions), use `t.Skip()` directives and version checks to adapt test behaviour as appropriate. For example:
-https://github.com/hashicorp/terraform-exec/blob/d0cb3efafda90dd47bbfabdccde3cf7e45e0376d/tfexec/internal/e2etest/validate_test.go#L15-L23
+https://github.com/opentofu/tofu-exec/blob/d0cb3efafda90dd47bbfabdccde3cf7e45e0376d/tfexec/internal/e2etest/validate_test.go#L15-L23
 
 The `runTestWithVersions()` helper can be used to run tests against specific Terraform versions. This should be used only alongside a test using `runTest()` to cover the remaining past and future versions.
 
 ## Versioning
 
-The `github.com/hashicorp/terraform-exec` Go module in its entirety is versioned according to [Go module versioning](https://golang.org/ref/mod#versions) with Git tags. The latest version is automatically written to `internal/version/version.go` during the release process.
+The `github.com/opentofu/tofu-exec` Go module in its entirety is versioned according to [Go module versioning](https://golang.org/ref/mod#versions) with Git tags. The latest version is automatically written to `internal/version/version.go` during the release process.
 
 ## Releases
 
@@ -83,12 +85,12 @@ Releases are made on a reasonably regular basis by the Terraform team, using our
 
 The following notes are only relevant to maintainers.
 
-1. Make sure [CHANGELOG.md](https://github.com/hashicorp/terraform-exec/blob/main/CHANGELOG.md) has all **changes** and the first line has the **version** you're intending to release (with ` (Unreleased)` suffix).
-1. Trigger the [`release` workflow](https://github.com/hashicorp/terraform-exec/actions/workflows/release.yml) from GitHub UI. This will run the [release script](https://github.com/hashicorp/terraform-exec/blob/main/scripts/release/release.sh). As part of that script:
+1. Make sure [CHANGELOG.md](https://github.com/opentofu/tofu-exec/blob/main/CHANGELOG.md) has all **changes** and the first line has the **version** you're intending to release (with ` (Unreleased)` suffix).
+1. Trigger the [`release` workflow](https://github.com/opentofu/tofu-exec/actions/workflows/release.yml) from GitHub UI. This will run the [release script](https://github.com/opentofu/tofu-exec/blob/main/scripts/release/release.sh). As part of that script:
   - `Unreleased`, `[GH-XXX]` will be replaced.
-  - The [version](https://github.com/hashicorp/terraform-exec/blob/main/internal/version/version.go#L3) will be bumped to match the one parsed from `CHANGELOG.md`.
+  - The [version](https://github.com/opentofu/tofu-exec/blob/main/internal/version/version.go#L3) will be bumped to match the one parsed from `CHANGELOG.md`.
   - Tag will be pushed
-1. [Create new release](https://github.com/hashicorp/terraform-exec/releases/new) via GitHub UI to point to the new tag and copy the appropriate part of the CHANGELOG.md there.
+1. [Create new release](https://github.com/opentofu/tofu-exec/releases/new) via GitHub UI to point to the new tag and copy the appropriate part of the CHANGELOG.md there.
 
 ## Security vulnerabilities
 
@@ -103,7 +105,7 @@ In general we do not accept PRs containing only the following changes:
  - Correcting spelling or typos
  - Code formatting, including whitespace
  - Other cosmetic changes that do not affect functionality
- 
+
 While we appreciate the effort that goes into preparing PRs, there is always a tradeoff between benefit and cost. The costs involved in accepting such contributions include the time taken for thorough review, the noise created in the git history, and the increased number of GitHub notifications that maintainers must attend to.
 
 #### Exceptions

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# This repository is work in progress
+# This repository is a work in progress
 
-This repository is currently not usable and requires large set of changes, to make it so.
-We are going to update this respository for the sole purpose of using it in [`tofu-ls`](https://github.com/opentofu/tofu-ls).
-This document will be updated as a part of those changes. Currently, we do not recommend using this library for the uses outside of `tofu-ls`. [Link to the Issue](https://github.com/opentofu/opentofu/issues/2455#issuecomment-2858320418)
+This repository is currently not usable and requires a large set of changes to make it so.
+We are going to update this repository solely to use it in [`tofu-ls`](https://github.com/opentofu/tofu-ls).
+This document will be updated as part of those changes. We do not recommend using this library outside of [`tofu-ls`](https://github.com/opentofu/tofu-ls). [Link to the Issue](https://github.com/opentofu/opentofu/issues/2455#issuecomment-2858320418)
 
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/hashicorp/terraform-exec)](https://pkg.go.dev/github.com/hashicorp/terraform-exec)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/opentofu/tofu-exec)](https://pkg.go.dev/github.com/opentofu/tofu-exec)
 
-# terraform-exec
+# tofu-exec
 
 A Go module for constructing and running [Terraform](https://terraform.io) CLI commands. Structured return values use the data types defined in [terraform-json](https://github.com/hashicorp/terraform-json).
 
 The [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) is the canonical Go interface for Terraform plugins using the gRPC protocol. This library is intended for use in Go programs that make use of Terraform's other interface, the CLI. Importing this library is preferable to importing `github.com/hashicorp/terraform/command`, because the latter is not intended for use outside Terraform Core.
 
-While terraform-exec is already widely used, please note that this module is **not yet at v1.0.0**, and that therefore breaking changes may occur in minor releases.
+While tofu-exec is already widely used, please note that this module is **not yet at v1.0.0**, and that therefore breaking changes may occur in minor releases.
 
 We strictly follow [semantic versioning](https://semver.org).
 
 ## Go compatibility
 
-This library is built in Go, and uses the [support policy](https://golang.org/doc/devel/release.html#policy) of Go as its support policy. The two latest major releases of Go are supported by terraform-exec.
+This library is built in Go, and uses the [support policy](https://golang.org/doc/devel/release.html#policy) of Go as its support policy. The two latest major releases of Go are supported by tofu-exec.
 
 Currently, that means Go **1.18** or later must be used.
 
 ## Usage
 
-The `Terraform` struct must be initialised with `NewTerraform(workingDir, execPath)`. 
+The `Terraform` struct must be initialised with `NewTerraform(workingDir, execPath)`.
 
 Top-level Terraform commands each have their own function, which will return either `error` or `(T, error)`, where `T` is a `terraform-json` type.
 
@@ -44,7 +44,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func main() {
@@ -80,14 +80,14 @@ func main() {
 
 ## Testing Terraform binaries
 
-The terraform-exec test suite contains end-to-end tests which run realistic workflows against a real Terraform binary using `tfexec.Terraform{}`.
+The tofu-exec test suite contains end-to-end tests which run realistic workflows against a real Terraform binary using `tfexec.Terraform{}`.
 
 To run these tests with a local Terraform binary, set the environment variable `TFEXEC_E2ETEST_TERRAFORM_PATH` to its path and run:
 ```sh
 go test -timeout=20m ./tfexec/internal/e2etest
 ```
 
-For more information on terraform-exec's test suite, please see Contributing below.
+For more information on tofu-exec's test suite, please see Contributing below.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/terraform-exec
+module github.com/opentofu/tofu-exec
 
 go 1.24
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 
 const version = "0.19.0"
 
-// ModuleVersion returns the current version of the github.com/hashicorp/terraform-exec Go module.
+// ModuleVersion returns the current version of the github.com/opentofu/tofu-exec Go module.
 // This is a function to allow for future possible enhancement using debug.BuildInfo.
 func ModuleVersion() string {
 	return version

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestApplyCmd(t *testing.T) {

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -18,7 +18,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/hashicorp/terraform-exec/internal/version"
+	"github.com/opentofu/tofu-exec/internal/version"
 )
 
 const (

--- a/tfexec/cmd_test.go
+++ b/tfexec/cmd_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/internal/version"
+	"github.com/opentofu/tofu-exec/internal/version"
 )
 
 func TestMergeUserAgent(t *testing.T) {

--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestDestroyCmd(t *testing.T) {

--- a/tfexec/fmt_test.go
+++ b/tfexec/fmt_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestFormatCmd(t *testing.T) {

--- a/tfexec/force_unlock_test.go
+++ b/tfexec/force_unlock_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestForceUnlockCmd(t *testing.T) {

--- a/tfexec/get_test.go
+++ b/tfexec/get_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestGetCmd(t *testing.T) {

--- a/tfexec/graph_test.go
+++ b/tfexec/graph_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestGraphCmd_v013(t *testing.T) {

--- a/tfexec/import_test.go
+++ b/tfexec/import_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestImportCmd(t *testing.T) {

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestInitCmd_v012(t *testing.T) {

--- a/tfexec/internal/e2etest/apply_test.go
+++ b/tfexec/internal/e2etest/apply_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 var (

--- a/tfexec/internal/e2etest/destroy_test.go
+++ b/tfexec/internal/e2etest/destroy_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestDestroy(t *testing.T) {

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 var (

--- a/tfexec/internal/e2etest/fmt_test.go
+++ b/tfexec/internal/e2etest/fmt_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestFormatString(t *testing.T) {

--- a/tfexec/internal/e2etest/force_unlock_test.go
+++ b/tfexec/internal/e2etest/force_unlock_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 // LockID set in the test fixture

--- a/tfexec/internal/e2etest/graph_test.go
+++ b/tfexec/internal/e2etest/graph_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestGraph(t *testing.T) {

--- a/tfexec/internal/e2etest/import_test.go
+++ b/tfexec/internal/e2etest/import_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestImport(t *testing.T) {

--- a/tfexec/internal/e2etest/init_test.go
+++ b/tfexec/internal/e2etest/init_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestInit(t *testing.T) {

--- a/tfexec/internal/e2etest/main_test.go
+++ b/tfexec/internal/e2etest/main_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 var tfcache *testutil.TFCache

--- a/tfexec/internal/e2etest/metadata_functions_test.go
+++ b/tfexec/internal/e2etest/metadata_functions_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestMetadataFunctions(t *testing.T) {

--- a/tfexec/internal/e2etest/output_test.go
+++ b/tfexec/internal/e2etest/output_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestOutput_noOutputs(t *testing.T) {

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestPlan(t *testing.T) {

--- a/tfexec/internal/e2etest/providers_lock_test.go
+++ b/tfexec/internal/e2etest/providers_lock_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 var (

--- a/tfexec/internal/e2etest/providers_schema_test.go
+++ b/tfexec/internal/e2etest/providers_schema_test.go
@@ -14,7 +14,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 var (

--- a/tfexec/internal/e2etest/refresh_test.go
+++ b/tfexec/internal/e2etest/refresh_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestRefresh(t *testing.T) {

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 var (

--- a/tfexec/internal/e2etest/state_mv_test.go
+++ b/tfexec/internal/e2etest/state_mv_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestStateMv(t *testing.T) {

--- a/tfexec/internal/e2etest/state_pull_test.go
+++ b/tfexec/internal/e2etest/state_pull_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestStatePull(t *testing.T) {

--- a/tfexec/internal/e2etest/state_push_test.go
+++ b/tfexec/internal/e2etest/state_push_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestStatePush(t *testing.T) {

--- a/tfexec/internal/e2etest/state_rm_test.go
+++ b/tfexec/internal/e2etest/state_rm_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestStateRm(t *testing.T) {

--- a/tfexec/internal/e2etest/taint_test.go
+++ b/tfexec/internal/e2etest/taint_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestTaint(t *testing.T) {

--- a/tfexec/internal/e2etest/test_test.go
+++ b/tfexec/internal/e2etest/test_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 var (

--- a/tfexec/internal/e2etest/untaint_test.go
+++ b/tfexec/internal/e2etest/untaint_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestUntaint(t *testing.T) {

--- a/tfexec/internal/e2etest/upgrade012_test.go
+++ b/tfexec/internal/e2etest/upgrade012_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestUpgrade012(t *testing.T) {

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 const testFixtureDir = "testdata"

--- a/tfexec/internal/e2etest/validate_test.go
+++ b/tfexec/internal/e2etest/validate_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 var (

--- a/tfexec/internal/e2etest/version_test.go
+++ b/tfexec/internal/e2etest/version_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 func TestVersion(t *testing.T) {

--- a/tfexec/internal/e2etest/workspace_test.go
+++ b/tfexec/internal/e2etest/workspace_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 
-	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/opentofu/tofu-exec/tfexec"
 )
 
 const defaultWorkspace = "default"

--- a/tfexec/metadata_functions_test.go
+++ b/tfexec/metadata_functions_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestMetadataFunctionsCmd(t *testing.T) {

--- a/tfexec/output_test.go
+++ b/tfexec/output_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestOutputCmd(t *testing.T) {

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestPlanCmd(t *testing.T) {

--- a/tfexec/providers_lock_test.go
+++ b/tfexec/providers_lock_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestProvidersLockCmd(t *testing.T) {

--- a/tfexec/providers_schema_test.go
+++ b/tfexec/providers_schema_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestProvidersSchemaCmd(t *testing.T) {

--- a/tfexec/refresh_test.go
+++ b/tfexec/refresh_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestRefreshCmd(t *testing.T) {

--- a/tfexec/show_test.go
+++ b/tfexec/show_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestShowCmd(t *testing.T) {

--- a/tfexec/state_mv_test.go
+++ b/tfexec/state_mv_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestStateMvCmd(t *testing.T) {

--- a/tfexec/state_pull_test.go
+++ b/tfexec/state_pull_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestStatePull(t *testing.T) {

--- a/tfexec/state_push_test.go
+++ b/tfexec/state_push_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestStatePushCmd(t *testing.T) {

--- a/tfexec/state_rm_test.go
+++ b/tfexec/state_rm_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestStateRmCmd(t *testing.T) {

--- a/tfexec/taint_test.go
+++ b/tfexec/taint_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestTaintCmd(t *testing.T) {

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -14,7 +14,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 var tfCache *testutil.TFCache

--- a/tfexec/test_test.go
+++ b/tfexec/test_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestTestCmd(t *testing.T) {

--- a/tfexec/untaint_test.go
+++ b/tfexec/untaint_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestUntaintCmd(t *testing.T) {

--- a/tfexec/upgrade012_test.go
+++ b/tfexec/upgrade012_test.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestUpgrade012(t *testing.T) {

--- a/tfexec/upgrade013_test.go
+++ b/tfexec/upgrade013_test.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestUpgrade013(t *testing.T) {

--- a/tfexec/version_test.go
+++ b/tfexec/version_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func mustVersion(t *testing.T, s string) *version.Version {

--- a/tfexec/workspace_delete_test.go
+++ b/tfexec/workspace_delete_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestWorkspaceDeleteCmd(t *testing.T) {

--- a/tfexec/workspace_new_test.go
+++ b/tfexec/workspace_new_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestWorkspaceNewCmd(t *testing.T) {

--- a/tfexec/workspace_show_test.go
+++ b/tfexec/workspace_show_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/opentofu/tofu-exec/tfexec/internal/testutil"
 )
 
 func TestWorkspaceShowCmd_v1(t *testing.T) {


### PR DESCRIPTION
Renames:
- Renames module from github.com/hashicorp/terraform-exec to github.com/opentofu/tofu-exec
- Renames relevant references from `terraform-exec` to `tofu-exec`