### PR TITLE
Renaming Terraform struct to Tofu

### DIFF
--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -108,7 +108,7 @@ func (opt *DestroyFlagOption) configureApply(conf *applyConfig) {
 }
 
 // Apply represents the terraform apply subcommand.
-func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
+func (tf *Tofu) Apply(ctx context.Context, opts ...ApplyOption) error {
 	cmd, err := tf.applyCmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
 // [machine-readable](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)
 // JSON being written to the supplied `io.Writer`. ApplyJSON is likely to be
 // removed in a future major version in favour of Apply returning JSON by default.
-func (tf *Terraform) ApplyJSON(ctx context.Context, w io.Writer, opts ...ApplyOption) error {
+func (tf *Tofu) ApplyJSON(ctx context.Context, w io.Writer, opts ...ApplyOption) error {
 	err := tf.compatible(ctx, tf0_15_3, nil)
 	if err != nil {
 		return fmt.Errorf("terraform apply -json was added in 0.15.3: %w", err)
@@ -137,7 +137,7 @@ func (tf *Terraform) ApplyJSON(ctx context.Context, w io.Writer, opts ...ApplyOp
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
+func (tf *Tofu) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
 	c := defaultApplyOptions
 
 	for _, o := range opts {
@@ -152,7 +152,7 @@ func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.C
 	return tf.buildApplyCmd(ctx, c, args)
 }
 
-func (tf *Terraform) applyJSONCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
+func (tf *Tofu) applyJSONCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
 	c := defaultApplyOptions
 
 	for _, o := range opts {
@@ -169,7 +169,7 @@ func (tf *Terraform) applyJSONCmd(ctx context.Context, opts ...ApplyOption) (*ex
 	return tf.buildApplyCmd(ctx, c, args)
 }
 
-func (tf *Terraform) buildApplyArgs(ctx context.Context, c applyConfig) ([]string, error) {
+func (tf *Tofu) buildApplyArgs(ctx context.Context, c applyConfig) ([]string, error) {
 	args := []string{"apply", "-no-color", "-auto-approve", "-input=false"}
 
 	// string opts: only pass if set
@@ -237,7 +237,7 @@ func (tf *Terraform) buildApplyArgs(ctx context.Context, c applyConfig) ([]strin
 	return args, nil
 }
 
-func (tf *Terraform) buildApplyCmd(ctx context.Context, c applyConfig, args []string) (*exec.Cmd, error) {
+func (tf *Tofu) buildApplyCmd(ctx context.Context, c applyConfig, args []string) (*exec.Cmd, error) {
 	// string argument: pass if set
 	if c.dirOrPlan != "" {
 		args = append(args, c.dirOrPlan)

--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -113,7 +113,7 @@ func (tf *Tofu) Apply(ctx context.Context, opts ...ApplyOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 // ApplyJSON represents the terraform apply subcommand with the `-json` flag.
@@ -134,7 +134,7 @@ func (tf *Tofu) ApplyJSON(ctx context.Context, w io.Writer, opts ...ApplyOption)
 		return err
 	}
 
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
@@ -252,5 +252,5 @@ func (tf *Tofu) buildApplyCmd(ctx context.Context, c applyConfig, args []string)
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -15,7 +15,7 @@ import (
 func TestApplyCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestApplyCmd(t *testing.T) {
 func TestApplyJSONCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -122,7 +122,7 @@ func envSlice(environ map[string]string) []string {
 	return env
 }
 
-func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
+func (tf *Tofu) buildEnv(mergeEnv map[string]string) []string {
 	// set Terraform level env, if env is nil, fall back to os.Environ
 	var env map[string]string
 	if tf.env == nil {
@@ -184,7 +184,7 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 	return envSlice(env)
 }
 
-func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
+func (tf *Tofu) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, tf.execPath, args...)
 
 	cmd.Env = tf.buildEnv(mergeEnv)
@@ -195,7 +195,7 @@ func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]
 	return cmd
 }
 
-func (tf *Terraform) runTerraformCmdJSON(ctx context.Context, cmd *exec.Cmd, v interface{}) error {
+func (tf *Tofu) runTerraformCmdJSON(ctx context.Context, cmd *exec.Cmd, v interface{}) error {
 	var outbuf = bytes.Buffer{}
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outbuf)
 

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -184,7 +184,7 @@ func (tf *Tofu) buildEnv(mergeEnv map[string]string) []string {
 	return envSlice(env)
 }
 
-func (tf *Tofu) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
+func (tf *Tofu) buildTofuCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, tf.execPath, args...)
 
 	cmd.Env = tf.buildEnv(mergeEnv)
@@ -195,11 +195,11 @@ func (tf *Tofu) buildTerraformCmd(ctx context.Context, mergeEnv map[string]strin
 	return cmd
 }
 
-func (tf *Tofu) runTerraformCmdJSON(ctx context.Context, cmd *exec.Cmd, v interface{}) error {
+func (tf *Tofu) runTofuCmdJSON(ctx context.Context, cmd *exec.Cmd, v interface{}) error {
 	var outbuf = bytes.Buffer{}
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outbuf)
 
-	err := tf.runTerraformCmd(ctx, cmd)
+	err := tf.runTofuCmd(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 )
 
-func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
+func (tf *Tofu) runTofuCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
 	// check for early cancellation

--- a/tfexec/cmd_default_test.go
+++ b/tfexec/cmd_default_test.go
@@ -22,7 +22,7 @@ func Test_runTerraformCmd_default(t *testing.T) {
 	// go test -race -run Test_runTerraformCmd_default ./tfexec
 	var buf bytes.Buffer
 
-	tf := &Terraform{
+	tf := &Tofu{
 		logger:   log.New(&buf, "", 0),
 		execPath: "echo",
 	}

--- a/tfexec/cmd_default_test.go
+++ b/tfexec/cmd_default_test.go
@@ -17,9 +17,9 @@ import (
 	"time"
 )
 
-func Test_runTerraformCmd_default(t *testing.T) {
-	// Checks runTerraformCmd for race condition when using
-	// go test -race -run Test_runTerraformCmd_default ./tfexec
+func Test_runTofuCmd_default(t *testing.T) {
+	// Checks runTofuCmd for race condition when using
+	// go test -race -run Test_runTofuCmd_default ./tfexec
 	var buf bytes.Buffer
 
 	tf := &Tofu{
@@ -29,8 +29,8 @@ func Test_runTerraformCmd_default(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cmd := tf.buildTerraformCmd(ctx, nil, "hello tf-exec!")
-	err := tf.runTerraformCmd(ctx, cmd)
+	cmd := tf.buildTofuCmd(ctx, nil, "hello tf-exec!")
+	err := tf.runTofuCmd(ctx, cmd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 )
 
-func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
+func (tf *Tofu) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 )
 
-func (tf *Tofu) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
+func (tf *Tofu) runTofuCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/tfexec/cmd_linux_test.go
+++ b/tfexec/cmd_linux_test.go
@@ -19,7 +19,7 @@ func Test_runTerraformCmd_linux(t *testing.T) {
 	// go test -race -run Test_runTerraformCmd_linux ./tfexec -tags=linux
 	var buf bytes.Buffer
 
-	tf := &Terraform{
+	tf := &Tofu{
 		logger:   log.New(&buf, "", 0),
 		execPath: "echo",
 	}

--- a/tfexec/cmd_linux_test.go
+++ b/tfexec/cmd_linux_test.go
@@ -14,9 +14,9 @@ import (
 	"time"
 )
 
-func Test_runTerraformCmd_linux(t *testing.T) {
-	// Checks runTerraformCmd for race condition when using
-	// go test -race -run Test_runTerraformCmd_linux ./tfexec -tags=linux
+func Test_runTofuCmd_linux(t *testing.T) {
+	// Checks runTofuCmd for race condition when using
+	// go test -race -run Test_runTofuCmd_linux ./tfexec -tags=linux
 	var buf bytes.Buffer
 
 	tf := &Tofu{
@@ -26,8 +26,8 @@ func Test_runTerraformCmd_linux(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cmd := tf.buildTerraformCmd(ctx, nil, "hello tf-exec!")
-	err := tf.runTerraformCmd(ctx, cmd)
+	cmd := tf.buildTofuCmd(ctx, nil, "hello tf-exec!")
+	err := tf.runTofuCmd(ctx, cmd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -93,7 +93,7 @@ func (opt *ReattachOption) configureDestroy(conf *destroyConfig) {
 }
 
 // Destroy represents the terraform destroy subcommand.
-func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
+func (tf *Tofu) Destroy(ctx context.Context, opts ...DestroyOption) error {
 	cmd, err := tf.destroyCmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
 // [machine-readable](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)
 // JSON being written to the supplied `io.Writer`. DestroyJSON is likely to be
 // removed in a future major version in favour of Destroy returning JSON by default.
-func (tf *Terraform) DestroyJSON(ctx context.Context, w io.Writer, opts ...DestroyOption) error {
+func (tf *Tofu) DestroyJSON(ctx context.Context, w io.Writer, opts ...DestroyOption) error {
 	err := tf.compatible(ctx, tf0_15_3, nil)
 	if err != nil {
 		return fmt.Errorf("terraform destroy -json was added in 0.15.3: %w", err)
@@ -122,7 +122,7 @@ func (tf *Terraform) DestroyJSON(ctx context.Context, w io.Writer, opts ...Destr
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
+func (tf *Tofu) destroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
 	c := defaultDestroyOptions
 
 	for _, o := range opts {
@@ -134,7 +134,7 @@ func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) (*ex
 	return tf.buildDestroyCmd(ctx, c, args)
 }
 
-func (tf *Terraform) destroyJSONCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
+func (tf *Tofu) destroyJSONCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
 	c := defaultDestroyOptions
 
 	for _, o := range opts {
@@ -147,7 +147,7 @@ func (tf *Terraform) destroyJSONCmd(ctx context.Context, opts ...DestroyOption) 
 	return tf.buildDestroyCmd(ctx, c, args)
 }
 
-func (tf *Terraform) buildDestroyArgs(c destroyConfig) []string {
+func (tf *Tofu) buildDestroyArgs(c destroyConfig) []string {
 	args := []string{"destroy", "-no-color", "-auto-approve", "-input=false"}
 
 	// string opts: only pass if set
@@ -187,7 +187,7 @@ func (tf *Terraform) buildDestroyArgs(c destroyConfig) []string {
 	return args
 }
 
-func (tf *Terraform) buildDestroyCmd(ctx context.Context, c destroyConfig, args []string) (*exec.Cmd, error) {
+func (tf *Tofu) buildDestroyCmd(ctx context.Context, c destroyConfig, args []string) (*exec.Cmd, error) {
 	// optional positional argument
 	if c.dir != "" {
 		args = append(args, c.dir)

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -98,7 +98,7 @@ func (tf *Tofu) Destroy(ctx context.Context, opts ...DestroyOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 // DestroyJSON represents the terraform destroy subcommand with the `-json` flag.
@@ -119,7 +119,7 @@ func (tf *Tofu) DestroyJSON(ctx context.Context, w io.Writer, opts ...DestroyOpt
 		return err
 	}
 
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) destroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
@@ -202,5 +202,5 @@ func (tf *Tofu) buildDestroyCmd(ctx context.Context, c destroyConfig, args []str
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -15,7 +15,7 @@ import (
 func TestDestroyCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestDestroyCmd(t *testing.T) {
 func TestDestroyJSONCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -46,7 +46,7 @@ func FormatString(ctx context.Context, execPath string, content string) (string,
 }
 
 // FormatString formats a passed string.
-func (tf *Terraform) FormatString(ctx context.Context, content string) (string, error) {
+func (tf *Tofu) FormatString(ctx context.Context, content string) (string, error) {
 	in := strings.NewReader(content)
 	var outBuf strings.Builder
 	err := tf.Format(ctx, in, &outBuf)
@@ -58,7 +58,7 @@ func (tf *Terraform) FormatString(ctx context.Context, content string) (string, 
 
 // Format performs formatting on the unformatted io.Reader (as stdin to the CLI) and returns
 // the formatted result on the formatted io.Writer.
-func (tf *Terraform) Format(ctx context.Context, unformatted io.Reader, formatted io.Writer) error {
+func (tf *Tofu) Format(ctx context.Context, unformatted io.Reader, formatted io.Writer) error {
 	cmd, err := tf.formatCmd(ctx, nil, Dir("-"))
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (tf *Terraform) Format(ctx context.Context, unformatted io.Reader, formatte
 }
 
 // FormatWrite attempts to format and modify all config files in the working or selected (via DirOption) directory.
-func (tf *Terraform) FormatWrite(ctx context.Context, opts ...FormatOption) error {
+func (tf *Tofu) FormatWrite(ctx context.Context, opts ...FormatOption) error {
 	for _, o := range opts {
 		switch o := o.(type) {
 		case *DirOption:
@@ -90,7 +90,7 @@ func (tf *Terraform) FormatWrite(ctx context.Context, opts ...FormatOption) erro
 }
 
 // FormatCheck returns true if the config files in the working or selected (via DirOption) directory are already formatted.
-func (tf *Terraform) FormatCheck(ctx context.Context, opts ...FormatOption) (bool, []string, error) {
+func (tf *Tofu) FormatCheck(ctx context.Context, opts ...FormatOption) (bool, []string, error) {
 	for _, o := range opts {
 		switch o := o.(type) {
 		case *DirOption:
@@ -130,7 +130,7 @@ func (tf *Terraform) FormatCheck(ctx context.Context, opts ...FormatOption) (boo
 	return false, nil, err
 }
 
-func (tf *Terraform) formatCmd(ctx context.Context, args []string, opts ...FormatOption) (*exec.Cmd, error) {
+func (tf *Tofu) formatCmd(ctx context.Context, args []string, opts ...FormatOption) (*exec.Cmd, error) {
 	err := tf.compatible(ctx, tf0_7_7, nil)
 	if err != nil {
 		return nil, fmt.Errorf("fmt was first introduced in Terraform 0.7.7: %w", err)

--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -37,7 +37,7 @@ func (opt *DirOption) configureFormat(conf *formatConfig) {
 
 // FormatString formats a passed string, given a path to Terraform.
 func FormatString(ctx context.Context, execPath string, content string) (string, error) {
-	tf, err := NewTerraform(filepath.Dir(execPath), execPath)
+	tf, err := NewTofu(filepath.Dir(execPath), execPath)
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +67,7 @@ func (tf *Tofu) Format(ctx context.Context, unformatted io.Reader, formatted io.
 	cmd.Stdin = unformatted
 	cmd.Stdout = mergeWriters(cmd.Stdout, formatted)
 
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 // FormatWrite attempts to format and modify all config files in the working or selected (via DirOption) directory.
@@ -86,7 +86,7 @@ func (tf *Tofu) FormatWrite(ctx context.Context, opts ...FormatOption) error {
 		return err
 	}
 
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 // FormatCheck returns true if the config files in the working or selected (via DirOption) directory are already formatted.
@@ -108,7 +108,7 @@ func (tf *Tofu) FormatCheck(ctx context.Context, opts ...FormatOption) (bool, []
 	var outBuf strings.Builder
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outBuf)
 
-	err = tf.runTerraformCmd(ctx, cmd)
+	err = tf.runTofuCmd(ctx, cmd)
 	if err == nil {
 		return true, nil, nil
 	}
@@ -160,5 +160,5 @@ func (tf *Tofu) formatCmd(ctx context.Context, args []string, opts ...FormatOpti
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/fmt_test.go
+++ b/tfexec/fmt_test.go
@@ -20,7 +20,7 @@ func TestFormatCmd(t *testing.T) {
 
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1_1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/force_unlock.go
+++ b/tfexec/force_unlock.go
@@ -26,7 +26,7 @@ func (opt *DirOption) configureForceUnlock(conf *forceUnlockConfig) {
 }
 
 // ForceUnlock represents the `terraform force-unlock` command
-func (tf *Terraform) ForceUnlock(ctx context.Context, lockID string, opts ...ForceUnlockOption) error {
+func (tf *Tofu) ForceUnlock(ctx context.Context, lockID string, opts ...ForceUnlockOption) error {
 	unlockCmd, err := tf.forceUnlockCmd(ctx, lockID, opts...)
 	if err != nil {
 		return err
@@ -39,7 +39,7 @@ func (tf *Terraform) ForceUnlock(ctx context.Context, lockID string, opts ...For
 	return nil
 }
 
-func (tf *Terraform) forceUnlockCmd(ctx context.Context, lockID string, opts ...ForceUnlockOption) (*exec.Cmd, error) {
+func (tf *Tofu) forceUnlockCmd(ctx context.Context, lockID string, opts ...ForceUnlockOption) (*exec.Cmd, error) {
 	c := defaultForceUnlockOptions
 
 	for _, o := range opts {

--- a/tfexec/force_unlock.go
+++ b/tfexec/force_unlock.go
@@ -32,7 +32,7 @@ func (tf *Tofu) ForceUnlock(ctx context.Context, lockID string, opts ...ForceUnl
 		return err
 	}
 
-	if err := tf.runTerraformCmd(ctx, unlockCmd); err != nil {
+	if err := tf.runTofuCmd(ctx, unlockCmd); err != nil {
 		return err
 	}
 
@@ -59,5 +59,5 @@ func (tf *Tofu) forceUnlockCmd(ctx context.Context, lockID string, opts ...Force
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/force_unlock_test.go
+++ b/tfexec/force_unlock_test.go
@@ -15,7 +15,7 @@ import (
 func TestForceUnlockCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1_1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestForceUnlockCmd(t *testing.T) {
 func TestForceUnlockCmd_pre015(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest014))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest014))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/get.go
+++ b/tfexec/get.go
@@ -35,7 +35,7 @@ func (tf *Tofu) Get(ctx context.Context, opts ...GetCmdOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) getCmd(ctx context.Context, opts ...GetCmdOption) (*exec.Cmd, error) {
@@ -53,5 +53,5 @@ func (tf *Tofu) getCmd(ctx context.Context, opts ...GetCmdOption) (*exec.Cmd, er
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/get.go
+++ b/tfexec/get.go
@@ -30,7 +30,7 @@ func (opt *UpdateOption) configureGet(conf *getCmdConfig) {
 }
 
 // Get represents the terraform get subcommand.
-func (tf *Terraform) Get(ctx context.Context, opts ...GetCmdOption) error {
+func (tf *Tofu) Get(ctx context.Context, opts ...GetCmdOption) error {
 	cmd, err := tf.getCmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func (tf *Terraform) Get(ctx context.Context, opts ...GetCmdOption) error {
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) getCmd(ctx context.Context, opts ...GetCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) getCmd(ctx context.Context, opts ...GetCmdOption) (*exec.Cmd, error) {
 	c := getCmdConfig{}
 
 	for _, o := range opts {

--- a/tfexec/get_test.go
+++ b/tfexec/get_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/graph.go
+++ b/tfexec/graph.go
@@ -43,7 +43,7 @@ func (tf *Tofu) Graph(ctx context.Context, opts ...GraphOption) (string, error) 
 	}
 	var outBuf strings.Builder
 	graphCmd.Stdout = &outBuf
-	err = tf.runTerraformCmd(ctx, graphCmd)
+	err = tf.runTofuCmd(ctx, graphCmd)
 	if err != nil {
 		return "", err
 	}
@@ -86,5 +86,5 @@ func (tf *Tofu) graphCmd(ctx context.Context, opts ...GraphOption) (*exec.Cmd, e
 		args = append(args, "-type="+c.graphType)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/graph.go
+++ b/tfexec/graph.go
@@ -36,7 +36,7 @@ func (opt *GraphTypeOption) configureGraph(conf *graphConfig) {
 	conf.graphType = opt.graphType
 }
 
-func (tf *Terraform) Graph(ctx context.Context, opts ...GraphOption) (string, error) {
+func (tf *Tofu) Graph(ctx context.Context, opts ...GraphOption) (string, error) {
 	graphCmd, err := tf.graphCmd(ctx, opts...)
 	if err != nil {
 		return "", err
@@ -52,7 +52,7 @@ func (tf *Terraform) Graph(ctx context.Context, opts ...GraphOption) (string, er
 
 }
 
-func (tf *Terraform) graphCmd(ctx context.Context, opts ...GraphOption) (*exec.Cmd, error) {
+func (tf *Tofu) graphCmd(ctx context.Context, opts ...GraphOption) (*exec.Cmd, error) {
 	c := defaultGraphOptions
 
 	for _, o := range opts {

--- a/tfexec/graph_test.go
+++ b/tfexec/graph_test.go
@@ -20,7 +20,7 @@ func TestGraphCmd_v013(t *testing.T) {
 
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest013))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestGraphCmd_v013(t *testing.T) {
 func TestGraphCmd_v1(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -83,7 +83,7 @@ func (tf *Tofu) Import(ctx context.Context, address, id string, opts ...ImportOp
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) importCmd(ctx context.Context, address, id string, opts ...ImportOption) (*exec.Cmd, error) {
@@ -142,5 +142,5 @@ func (tf *Tofu) importCmd(ctx context.Context, address, id string, opts ...Impor
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -78,7 +78,7 @@ func (opt *VarFileOption) configureImport(conf *importConfig) {
 }
 
 // Import represents the terraform import subcommand.
-func (tf *Terraform) Import(ctx context.Context, address, id string, opts ...ImportOption) error {
+func (tf *Tofu) Import(ctx context.Context, address, id string, opts ...ImportOption) error {
 	cmd, err := tf.importCmd(ctx, address, id, opts...)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func (tf *Terraform) Import(ctx context.Context, address, id string, opts ...Imp
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) importCmd(ctx context.Context, address, id string, opts ...ImportOption) (*exec.Cmd, error) {
+func (tf *Tofu) importCmd(ctx context.Context, address, id string, opts ...ImportOption) (*exec.Cmd, error) {
 	c := defaultImportOptions
 
 	for _, o := range opts {

--- a/tfexec/import_test.go
+++ b/tfexec/import_test.go
@@ -15,7 +15,7 @@ import (
 func TestImportCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -102,7 +102,7 @@ func (opt *VerifyPluginsOption) configureInit(conf *initConfig) {
 }
 
 // Init represents the terraform init subcommand.
-func (tf *Terraform) Init(ctx context.Context, opts ...InitOption) error {
+func (tf *Tofu) Init(ctx context.Context, opts ...InitOption) error {
 	cmd, err := tf.initCmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (tf *Terraform) Init(ctx context.Context, opts ...InitOption) error {
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {
+func (tf *Tofu) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {
 	c := defaultInitOptions
 
 	for _, o := range opts {

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -107,7 +107,7 @@ func (tf *Tofu) Init(ctx context.Context, opts ...InitOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {
@@ -188,5 +188,5 @@ func (tf *Tofu) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, err
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -20,7 +20,7 @@ func TestInitCmd_v012(t *testing.T) {
 
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest012))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestInitCmd_v012(t *testing.T) {
 func TestInitCmd_v1(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/internal/e2etest/apply_test.go
+++ b/tfexec/internal/e2etest/apply_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 func TestApply(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -38,7 +38,7 @@ func TestApply(t *testing.T) {
 func TestApplyJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -56,7 +56,7 @@ func TestApplyJSON_TF014AndEarlier(t *testing.T) {
 func TestApplyJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -70,7 +70,7 @@ func TestApplyJSON_TF015AndLater(t *testing.T) {
 }
 
 func TestApplyDestroy(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(applyDestroyMinVersion) {
 			t.Skip("terraform apply -destroy was added in Terraform 0.15.2, so test is not valid")
 		}

--- a/tfexec/internal/e2etest/destroy_test.go
+++ b/tfexec/internal/e2etest/destroy_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDestroy(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -39,7 +39,7 @@ func TestDestroy(t *testing.T) {
 func TestDestroyJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -57,7 +57,7 @@ func TestDestroyJSON_TF014AndEarlier(t *testing.T) {
 func TestDestroyJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -30,7 +30,7 @@ var (
 func TestUnparsedError(t *testing.T) {
 	// This simulates an unparsed error from the Cmd.Run method (in this case file not found). This
 	// is to ensure we don't miss raising unexpected errors in addition to parsed / well known ones.
-	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 
 		// force delete the working dir to cause an os.PathError
 		err := os.RemoveAll(tf.WorkingDir())
@@ -50,7 +50,7 @@ func TestUnparsedError(t *testing.T) {
 }
 
 func TestMissingVar(t *testing.T) {
-	runTest(t, "var", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "var", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("err during init: %s", err)
@@ -84,7 +84,7 @@ func TestMissingVar(t *testing.T) {
 }
 
 func TestTFVersionMismatch(t *testing.T) {
-	runTest(t, "tf99", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "tf99", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// force cache version for error messaging
 		_, _, err := tf.Version(context.Background(), true)
 		if err != nil {
@@ -104,7 +104,7 @@ func TestTFVersionMismatch(t *testing.T) {
 }
 
 func TestLockedState(t *testing.T) {
-	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("err during init: %s", err)
@@ -122,7 +122,7 @@ func TestLockedState(t *testing.T) {
 }
 
 func TestContext_alreadyPastDeadline(t *testing.T) {
-	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
@@ -139,7 +139,7 @@ func TestContext_alreadyPastDeadline(t *testing.T) {
 
 func TestContext_sleepNoCancellation(t *testing.T) {
 	// this test is just to ensure that time_sleep works properly without cancellation
-	runTest(t, "sleep", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "sleep", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// only testing versions that can cancel mid apply
 		if !tfv.GreaterThanOrEqual(protocol5MinVersion) {
 			t.Skip("the ability to interrupt an apply was added in protocol 5.0 in Terraform 0.12, so test is not valid")
@@ -164,7 +164,7 @@ func TestContext_sleepNoCancellation(t *testing.T) {
 }
 
 func TestContext_sleepTimeoutExpired(t *testing.T) {
-	runTest(t, "sleep", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "sleep", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// only testing versions that can cancel mid apply
 		if !tfv.GreaterThanOrEqual(protocol5MinVersion) {
 			t.Skip("the ability to interrupt an apply was added in protocol 5.0 in Terraform 0.12, so test is not valid")
@@ -199,7 +199,7 @@ func TestContext_sleepTimeoutExpired(t *testing.T) {
 }
 
 func TestContext_alreadyCancelled(t *testing.T) {
-	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 

--- a/tfexec/internal/e2etest/fmt_test.go
+++ b/tfexec/internal/e2etest/fmt_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestFormatString(t *testing.T) {
-	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		unformatted := strings.TrimSpace(`
 resource     "foo"      "bar" {
 	baz = 1
@@ -50,7 +50,7 @@ resource "foo" "bar" {
 }
 
 func TestFormatCheck(t *testing.T) {
-	runTest(t, "unformatted", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "unformatted", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		checksums := map[string]uint32{
 			"file1.tf": checkSum(t, filepath.Join(tf.WorkingDir(), "file1.tf")),
 			"file2.tf": checkSum(t, filepath.Join(tf.WorkingDir(), "file2.tf")),
@@ -78,7 +78,7 @@ func TestFormatCheck(t *testing.T) {
 }
 
 func TestFormatWrite(t *testing.T) {
-	runTest(t, "unformatted", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "unformatted", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.FormatWrite(context.Background())
 		if err != nil {
 			t.Fatalf("error from FormatWrite: %T %q", err, err)
@@ -94,7 +94,7 @@ func TestFormatWrite(t *testing.T) {
 }
 
 func TestFormat(t *testing.T) {
-	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		unformatted := strings.TrimSpace(`
 resource     "foo"      "bar" {
 	baz = 1
@@ -126,7 +126,7 @@ resource "foo" "bar" {
 }
 
 func TestFormat_warmFormatter(t *testing.T) {
-	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		unformatted := strings.TrimSpace(`
 resource     "foo"      "bar" {
 	baz = 1

--- a/tfexec/internal/e2etest/force_unlock_test.go
+++ b/tfexec/internal/e2etest/force_unlock_test.go
@@ -20,7 +20,7 @@ const inmemLockID = "2b6a6738-5dd5-50d6-c0ae-f6352977666b"
 var forceUnlockDirArgMaxVersion = version.Must(version.NewVersion("0.15.0"))
 
 func TestForceUnlock(t *testing.T) {
-	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init: %v", err)
@@ -31,7 +31,7 @@ func TestForceUnlock(t *testing.T) {
 			t.Fatalf("error running ForceUnlock: %v", err)
 		}
 	})
-	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.GreaterThanOrEqual(forceUnlockDirArgMaxVersion) {
 			t.Skip("legacy positional path argument deprecated in favor of global -chdir flag")
 		}
@@ -45,7 +45,7 @@ func TestForceUnlock(t *testing.T) {
 			t.Fatalf("error running ForceUnlock: %v", err)
 		}
 	})
-	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "inmem_backend_locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init: %v", err)

--- a/tfexec/internal/e2etest/graph_test.go
+++ b/tfexec/internal/e2etest/graph_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGraph(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/import_test.go
+++ b/tfexec/internal/e2etest/import_test.go
@@ -20,7 +20,7 @@ func TestImport(t *testing.T) {
 		resourceAddress = "random_string.random_string"
 	)
 
-	runTest(t, "import", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "import", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		ctx := context.Background()
 
 		err := tf.Init(ctx)

--- a/tfexec/internal/e2etest/init_test.go
+++ b/tfexec/internal/e2etest/init_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/metadata_functions_test.go
+++ b/tfexec/internal/e2etest/metadata_functions_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestMetadataFunctions(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(metadataFunctionsMinVersion) {
 			t.Skip("metadata functions command is not available in this Terraform version")
 		}

--- a/tfexec/internal/e2etest/output_test.go
+++ b/tfexec/internal/e2etest/output_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestOutput_noOutputs(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(version.Must(version.NewVersion("0.12.14"))) {
 			// https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md#01214-november-13-2019
 			t.Skip("no outputs being success (instead of error) was changed in 0.12.14")

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestPlan(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -36,7 +36,7 @@ func TestPlan(t *testing.T) {
 }
 
 func TestPlanWithState(t *testing.T) {
-	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(providerAddressMinVersion) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}
@@ -58,7 +58,7 @@ func TestPlanWithState(t *testing.T) {
 func TestPlanJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -79,7 +79,7 @@ func TestPlanJSON_TF014AndEarlier(t *testing.T) {
 func TestPlanJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/providers_lock_test.go
+++ b/tfexec/internal/e2etest/providers_lock_test.go
@@ -19,7 +19,7 @@ var (
 )
 
 func TestProvidersLock(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(providersLockMinVersion) {
 			t.Skip("terraform providers lock was added in Terraform 0.14, so test is not valid")
 		}

--- a/tfexec/internal/e2etest/providers_schema_test.go
+++ b/tfexec/internal/e2etest/providers_schema_test.go
@@ -227,7 +227,7 @@ same can now be achieved using [locals](https://www.terraform.io/docs/language/v
 	} {
 		c := c
 		t.Run(fmt.Sprintf("%d %s", i, c.fixtureDir), func(t *testing.T) {
-			runTest(t, c.fixtureDir, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+			runTest(t, c.fixtureDir, func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 				if tfv.Core().LessThan(v0_12_0) {
 					t.Skip("providers schema -json was added in 0.12")
 				}

--- a/tfexec/internal/e2etest/refresh_test.go
+++ b/tfexec/internal/e2etest/refresh_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestRefresh(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -39,7 +39,7 @@ func TestRefresh(t *testing.T) {
 func TestRefreshJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -57,7 +57,7 @@ func TestRefreshJSON_TF014AndEarlier(t *testing.T) {
 func TestRefreshJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 func TestShow(t *testing.T) {
-	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 
 		if tfv.LessThan(providerAddressMinVersion) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
@@ -87,7 +87,7 @@ func TestShow(t *testing.T) {
 }
 
 func TestShow_emptyDir(t *testing.T) {
-	runTest(t, "empty", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "empty", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
@@ -121,7 +121,7 @@ func TestShow_noInitBasic(t *testing.T) {
 	// no providers to download, this is unintended behaviour, as
 	// init is not actually necessary. This is considered a known issue in
 	// pre-1.2.0 versions.
-	runTestWithVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		_, err := tf.Show(context.Background())
 		if err == nil {
 			t.Fatalf("expected error, but did not get one")
@@ -130,7 +130,7 @@ func TestShow_noInitBasic(t *testing.T) {
 
 	// From v1.2.0 onwards, running show before init in the basic case returns
 	// an empty state with no error.
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// HACK KEM: Really I mean tfv.LessThan(version.Must(version.NewVersion("1.2.0"))),
 		// but I want this test to run for refs/heads/main prior to the release of v1.2.0.
 		if tfv.LessThan(version.Must(version.NewVersion("1.2.0"))) {
@@ -158,7 +158,7 @@ func TestShow_noInitModule(t *testing.T) {
 	// no providers to download, this is unintended behaviour, as
 	// init is not actually necessary. This is considered a known issue in
 	// pre-1.2.0 versions.
-	runTestWithVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "registry_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "registry_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		_, err := tf.Show(context.Background())
 		if err == nil {
 			t.Fatalf("expected error, but did not get one")
@@ -167,7 +167,7 @@ func TestShow_noInitModule(t *testing.T) {
 
 	// From v1.2.0 onwards, running show before init in the basic case returns
 	// an empty state with no error.
-	runTest(t, "registry_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "registry_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// HACK KEM: Really I mean tfv.LessThan(version.Must(version.NewVersion("1.2.0"))),
 		// but I want this test to run for refs/heads/main prior to the release of v1.2.0.
 		if tfv.LessThanOrEqual(version.Must(version.NewVersion(testutil.Latest_v1_1))) {
@@ -189,7 +189,7 @@ func TestShow_noInitModule(t *testing.T) {
 }
 
 func TestShow_noInitInmemBackend(t *testing.T) {
-	runTest(t, "inmem_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "inmem_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
@@ -202,7 +202,7 @@ func TestShow_noInitInmemBackend(t *testing.T) {
 }
 
 func TestShow_noInitLocalBackendNonDefaultState(t *testing.T) {
-	runTest(t, "local_backend_non_default_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "local_backend_non_default_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
@@ -215,7 +215,7 @@ func TestShow_noInitLocalBackendNonDefaultState(t *testing.T) {
 }
 
 func TestShow_noInitCloudBackend(t *testing.T) {
-	runTest(t, "cloud_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "cloud_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(version.Must(version.NewVersion("1.1.0"))) {
 			t.Skip("cloud backend was added in Terraform 1.1, so test is not valid")
 		}
@@ -228,7 +228,7 @@ func TestShow_noInitCloudBackend(t *testing.T) {
 }
 
 func TestShow_noInitEtcdBackend(t *testing.T) {
-	runTest(t, "etcd_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "etcd_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
@@ -245,7 +245,7 @@ func TestShow_noInitEtcdBackend(t *testing.T) {
 }
 
 func TestShow_noInitRemoteBackend(t *testing.T) {
-	runTest(t, "remote_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "remote_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
@@ -258,7 +258,7 @@ func TestShow_noInitRemoteBackend(t *testing.T) {
 }
 
 func TestShow_statefileDoesNotExist(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
@@ -276,7 +276,7 @@ func TestShow_statefileDoesNotExist(t *testing.T) {
 }
 
 func TestShow_versionMismatch(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// only testing versions without show
 		if tfv.GreaterThanOrEqual(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
@@ -303,7 +303,7 @@ func TestShow_versionMismatch(t *testing.T) {
 // so we maintain one fixture per supported version.
 // See github.com/hashicorp/terraform/25920
 func TestShowStateFile012(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_statefile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_statefile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		expected := &tfjson.State{
 			FormatVersion: "0.1",
 			// TerraformVersion is ignored to facilitate latest version testing
@@ -341,7 +341,7 @@ func TestShowStateFile012(t *testing.T) {
 }
 
 func TestShowStateFile013(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest013, testutil.Latest014}, "non_default_statefile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest013, testutil.Latest014}, "non_default_statefile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		expected := &tfjson.State{
 			FormatVersion: "0.1",
 			// TerraformVersion is ignored to facilitate latest version testing
@@ -379,7 +379,7 @@ func TestShowStateFile013(t *testing.T) {
 }
 
 func TestShowStateFile014(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_statefile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_statefile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		expected := &tfjson.State{
 			FormatVersion: "0.1",
 			// TerraformVersion is ignored to facilitate latest version testing
@@ -419,7 +419,7 @@ func TestShowStateFile014(t *testing.T) {
 // Plan files cannot be transferred between different Terraform versions,
 // so we maintain one fixture per supported version
 func TestShowPlanFile012_linux(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if runtime.GOOS != "linux" {
 			t.Skip("plan file created in 0.12 on Linux is not compatible with other systems")
 		}
@@ -485,7 +485,7 @@ func TestShowPlanFile012_linux(t *testing.T) {
 }
 
 func TestShowPlanFile013(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		providerName := "registry.opentofu.org/hashicorp/null"
 
 		expected := &tfjson.Plan{
@@ -547,7 +547,7 @@ func TestShowPlanFile013(t *testing.T) {
 }
 
 func TestShowPlanFile014(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		providerName := "registry.opentofu.org/hashicorp/null"
 
 		expected := &tfjson.Plan{
@@ -612,7 +612,7 @@ func TestShowPlanFile014(t *testing.T) {
 }
 
 func TestShowPlanFileRaw012_linux(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if runtime.GOOS != "linux" {
 			t.Skip("plan file created in 0.12 on Linux is not compatible with other systems")
 		}
@@ -644,7 +644,7 @@ func TestShowPlanFileRaw012_linux(t *testing.T) {
 }
 
 func TestShowPlanFileRaw013(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		f, err := os.Open("testdata/non_default_planfile_013/human_readable_output.txt")
 		if err != nil {
 			t.Fatal(err)
@@ -672,7 +672,7 @@ func TestShowPlanFileRaw013(t *testing.T) {
 }
 
 func TestShowPlanFileRaw014(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		f, err := os.Open("testdata/non_default_planfile_013/human_readable_output.txt")
 		if err != nil {
 			t.Fatal(err)
@@ -699,7 +699,7 @@ func TestShowPlanFileRaw014(t *testing.T) {
 }
 
 func TestShowBigInt(t *testing.T) {
-	runTest(t, "bigint", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "bigint", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}

--- a/tfexec/internal/e2etest/state_mv_test.go
+++ b/tfexec/internal/e2etest/state_mv_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestStateMv(t *testing.T) {
-	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(providerAddressMinVersion) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}

--- a/tfexec/internal/e2etest/state_pull_test.go
+++ b/tfexec/internal/e2etest/state_pull_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestStatePull(t *testing.T) {
-	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(providerAddressMinVersion) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}

--- a/tfexec/internal/e2etest/state_push_test.go
+++ b/tfexec/internal/e2etest/state_push_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestStatePush(t *testing.T) {
-	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(providerAddressMinVersion) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}

--- a/tfexec/internal/e2etest/state_rm_test.go
+++ b/tfexec/internal/e2etest/state_rm_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestStateRm(t *testing.T) {
-	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(providerAddressMinVersion) {
 			t.Skip("state file provider FQNs not compatible with this Terraform version")
 		}

--- a/tfexec/internal/e2etest/taint_test.go
+++ b/tfexec/internal/e2etest/taint_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestTaint(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/test_test.go
+++ b/tfexec/internal/e2etest/test_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 func TestTest(t *testing.T) {
-	runTest(t, "test_command_passing", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "test_command_passing", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// Use Core() to enable pre-release support
 		if tfv.Core().LessThan(testMinVersion) {
 			t.Skip("test command is not available in this Terraform version")
@@ -36,7 +36,7 @@ func TestTest(t *testing.T) {
 }
 
 func TestTestError(t *testing.T) {
-	runTest(t, "test_command_failing", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "test_command_failing", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// Use Core() to enable pre-release support
 		if tfv.Core().LessThan(testMinVersion) {
 			t.Skip("test command is not available in this Terraform version")

--- a/tfexec/internal/e2etest/untaint_test.go
+++ b/tfexec/internal/e2etest/untaint_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestUntaint(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/upgrade012_test.go
+++ b/tfexec/internal/e2etest/upgrade012_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestUpgrade012(t *testing.T) {
-	runTestWithVersions(t, []string{testutil.Latest012}, "pre_011_syntax", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "pre_011_syntax", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -65,7 +65,7 @@ func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *
 		t.Cleanup(func() {
 			os.RemoveAll(td)
 		})
-		ltf, err := tfexec.NewTerraform(td, localBinPath)
+		ltf, err := tfexec.NewTofu(td, localBinPath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +121,7 @@ func runTestWithVersions(t *testing.T, versions []string, fixtureName string, cb
 				execPath = tfcache.Version(t, tfv)
 			}
 
-			tf, err := tfexec.NewTerraform(td, execPath)
+			tf, err := tfexec.NewTofu(td, execPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -33,7 +33,7 @@ var (
 	metadataFunctionsMinVersion = version.Must(version.NewVersion("1.4.0"))
 )
 
-func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
+func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Tofu)) {
 	t.Helper()
 
 	versions := []string{
@@ -83,7 +83,7 @@ func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *
 	runTestWithVersions(t, versions, fixtureName, cb)
 }
 
-func runTestWithVersions(t *testing.T, versions []string, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
+func runTestWithVersions(t *testing.T, versions []string, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Tofu)) {
 	t.Helper()
 
 	alreadyRunVersions := map[string]bool{}

--- a/tfexec/internal/e2etest/validate_test.go
+++ b/tfexec/internal/e2etest/validate_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 func TestValidate(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(validateMinVersion) {
 			t.Skip("terraform validate -json was added in Terraform 0.12, so test is not valid")
 		}
@@ -41,7 +41,7 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
-	runTest(t, "invalid", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "invalid", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		if tfv.LessThan(validateMinVersion) {
 			t.Skip("terraform validate -json was added in Terraform 0.12, so test is not valid")
 		}

--- a/tfexec/internal/e2etest/version_test.go
+++ b/tfexec/internal/e2etest/version_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		ctx := context.Background()
 
 		err := tf.Init(ctx)

--- a/tfexec/internal/e2etest/workspace_test.go
+++ b/tfexec/internal/e2etest/workspace_test.go
@@ -18,7 +18,7 @@ import (
 const defaultWorkspace = "default"
 
 func TestWorkspace_default_only(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		assertWorkspaceList(t, tf, defaultWorkspace)
 		assertWorkspaceShow(t, tf, defaultWorkspace)
 
@@ -46,7 +46,7 @@ func TestWorkspace_default_only(t *testing.T) {
 }
 
 func TestWorkspace_does_not_exist(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		const doesNotExistWorkspace = "does-not-exist"
 		err := tf.WorkspaceSelect(context.Background(), doesNotExistWorkspace)
 		if err == nil {
@@ -56,7 +56,7 @@ func TestWorkspace_does_not_exist(t *testing.T) {
 }
 
 func TestWorkspace_already_exists(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		const newWorkspace = "existing-workspace"
 		t.Run("create new workspace", func(t *testing.T) {
 			err := tf.WorkspaceNew(context.Background(), newWorkspace)
@@ -79,7 +79,7 @@ func TestWorkspace_already_exists(t *testing.T) {
 }
 
 func TestWorkspace_multiple(t *testing.T) {
-	runTest(t, "workspaces", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "workspaces", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		assertWorkspaceList(t, tf, "foo", "foo")
 		assertWorkspaceShow(t, tf, "foo")
 
@@ -108,7 +108,7 @@ func TestWorkspace_multiple(t *testing.T) {
 }
 
 func TestWorkspace_deletion(t *testing.T) {
-	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		assertWorkspaceList(t, tf, defaultWorkspace)
 		assertWorkspaceShow(t, tf, defaultWorkspace)
 
@@ -141,7 +141,7 @@ func TestWorkspace_deletion(t *testing.T) {
 	})
 }
 
-func assertWorkspaceList(t *testing.T, tf *tfexec.Terraform, expectedCurrent string, expectedWorkspaces ...string) {
+func assertWorkspaceList(t *testing.T, tf *tfexec.Tofu, expectedCurrent string, expectedWorkspaces ...string) {
 	actualWorkspaces, actualCurrent, err := tf.WorkspaceList(context.Background())
 	if err != nil {
 		t.Fatalf("got error querying workspace list: %s", err)
@@ -155,7 +155,7 @@ func assertWorkspaceList(t *testing.T, tf *tfexec.Terraform, expectedCurrent str
 	}
 }
 
-func assertWorkspaceShow(t *testing.T, tf *tfexec.Terraform, expectedWorkspace string) {
+func assertWorkspaceShow(t *testing.T, tf *tfexec.Tofu, expectedWorkspace string) {
 	actualWorkspace, err := tf.WorkspaceShow(context.Background())
 	if err != nil {
 		t.Fatalf("got error querying workspace show: %s", err)

--- a/tfexec/metadata_functions.go
+++ b/tfexec/metadata_functions.go
@@ -23,7 +23,7 @@ func (tf *Tofu) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFunction
 	functionsCmd := tf.metadataFunctionsCmd(ctx)
 
 	var ret tfjson.MetadataFunctions
-	err = tf.runTerraformCmdJSON(ctx, functionsCmd, &ret)
+	err = tf.runTofuCmdJSON(ctx, functionsCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -35,5 +35,5 @@ func (tf *Tofu) metadataFunctionsCmd(ctx context.Context, args ...string) *exec.
 	allArgs := []string{"metadata", "functions", "-json"}
 	allArgs = append(allArgs, args...)
 
-	return tf.buildTerraformCmd(ctx, nil, allArgs...)
+	return tf.buildTofuCmd(ctx, nil, allArgs...)
 }

--- a/tfexec/metadata_functions.go
+++ b/tfexec/metadata_functions.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MetadataFunctions represents the terraform metadata functions -json subcommand.
-func (tf *Terraform) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFunctions, error) {
+func (tf *Tofu) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFunctions, error) {
 	err := tf.compatible(ctx, tf1_4_0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("terraform metadata functions was added in 1.4.0: %w", err)
@@ -31,7 +31,7 @@ func (tf *Terraform) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFun
 	return &ret, nil
 }
 
-func (tf *Terraform) metadataFunctionsCmd(ctx context.Context, args ...string) *exec.Cmd {
+func (tf *Tofu) metadataFunctionsCmd(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"metadata", "functions", "-json"}
 	allArgs = append(allArgs, args...)
 

--- a/tfexec/metadata_functions_test.go
+++ b/tfexec/metadata_functions_test.go
@@ -15,7 +15,7 @@ import (
 func TestMetadataFunctionsCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1_1))
 	// tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_4)) // TODO! enable after 1.4 release
 	if err != nil {
 		t.Fatal(err)

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -38,7 +38,7 @@ type OutputMeta struct {
 }
 
 // Output represents the terraform output subcommand.
-func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[string]OutputMeta, error) {
+func (tf *Tofu) Output(ctx context.Context, opts ...OutputOption) (map[string]OutputMeta, error) {
 	outputCmd := tf.outputCmd(ctx, opts...)
 
 	outputs := map[string]OutputMeta{}
@@ -50,7 +50,7 @@ func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[stri
 	return outputs, nil
 }
 
-func (tf *Terraform) outputCmd(ctx context.Context, opts ...OutputOption) *exec.Cmd {
+func (tf *Tofu) outputCmd(ctx context.Context, opts ...OutputOption) *exec.Cmd {
 	c := defaultOutputOptions
 
 	for _, o := range opts {

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -42,7 +42,7 @@ func (tf *Tofu) Output(ctx context.Context, opts ...OutputOption) (map[string]Ou
 	outputCmd := tf.outputCmd(ctx, opts...)
 
 	outputs := map[string]OutputMeta{}
-	err := tf.runTerraformCmdJSON(ctx, outputCmd, &outputs)
+	err := tf.runTofuCmdJSON(ctx, outputCmd, &outputs)
 	if err != nil {
 		return nil, err
 	}
@@ -64,5 +64,5 @@ func (tf *Tofu) outputCmd(ctx context.Context, opts ...OutputOption) *exec.Cmd {
 		args = append(args, "-state="+c.state)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTofuCmd(ctx, nil, args...)
 }

--- a/tfexec/output_test.go
+++ b/tfexec/output_test.go
@@ -15,7 +15,7 @@ import (
 func TestOutputCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -112,7 +112,7 @@ func (tf *Tofu) Plan(ctx context.Context, opts ...PlanOption) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	err = tf.runTerraformCmd(ctx, cmd)
+	err = tf.runTofuCmd(ctx, cmd)
 	if err != nil && cmd.ProcessState.ExitCode() == 2 {
 		return true, nil
 	}
@@ -147,7 +147,7 @@ func (tf *Tofu) PlanJSON(ctx context.Context, w io.Writer, opts ...PlanOption) (
 		return false, err
 	}
 
-	err = tf.runTerraformCmd(ctx, cmd)
+	err = tf.runTofuCmd(ctx, cmd)
 	if err != nil && cmd.ProcessState.ExitCode() == 2 {
 		return true, nil
 	}
@@ -264,5 +264,5 @@ func (tf *Tofu) buildPlanCmd(ctx context.Context, c planConfig, args []string) (
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -107,7 +107,7 @@ func (opt *DestroyFlagOption) configurePlan(conf *planConfig) {
 //
 // The returned error is nil if `terraform plan` has been executed and exits
 // with either 0 or 2.
-func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) (bool, error) {
+func (tf *Tofu) Plan(ctx context.Context, opts ...PlanOption) (bool, error) {
 	cmd, err := tf.planCmd(ctx, opts...)
 	if err != nil {
 		return false, err
@@ -134,7 +134,7 @@ func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) (bool, error)
 //
 // PlanJSON is likely to be removed in a future major version in favour of
 // Plan returning JSON by default.
-func (tf *Terraform) PlanJSON(ctx context.Context, w io.Writer, opts ...PlanOption) (bool, error) {
+func (tf *Tofu) PlanJSON(ctx context.Context, w io.Writer, opts ...PlanOption) (bool, error) {
 	err := tf.compatible(ctx, tf0_15_3, nil)
 	if err != nil {
 		return false, fmt.Errorf("terraform plan -json was added in 0.15.3: %w", err)
@@ -155,7 +155,7 @@ func (tf *Terraform) PlanJSON(ctx context.Context, w io.Writer, opts ...PlanOpti
 	return false, err
 }
 
-func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd, error) {
+func (tf *Tofu) planCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd, error) {
 	c := defaultPlanOptions
 
 	for _, o := range opts {
@@ -170,7 +170,7 @@ func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd
 	return tf.buildPlanCmd(ctx, c, args)
 }
 
-func (tf *Terraform) planJSONCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd, error) {
+func (tf *Tofu) planJSONCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd, error) {
 	c := defaultPlanOptions
 
 	for _, o := range opts {
@@ -187,7 +187,7 @@ func (tf *Terraform) planJSONCmd(ctx context.Context, opts ...PlanOption) (*exec
 	return tf.buildPlanCmd(ctx, c, args)
 }
 
-func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string, error) {
+func (tf *Tofu) buildPlanArgs(ctx context.Context, c planConfig) ([]string, error) {
 	args := []string{"plan", "-no-color", "-input=false", "-detailed-exitcode"}
 
 	// string opts: only pass if set
@@ -249,7 +249,7 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 	return args, nil
 }
 
-func (tf *Terraform) buildPlanCmd(ctx context.Context, c planConfig, args []string) (*exec.Cmd, error) {
+func (tf *Tofu) buildPlanCmd(ctx context.Context, c planConfig, args []string) (*exec.Cmd, error) {
 	// optional positional argument
 	if c.dir != "" {
 		args = append(args, c.dir)

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -15,7 +15,7 @@ import (
 func TestPlanCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestPlanCmd(t *testing.T) {
 func TestPlanJSONCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/providers_lock.go
+++ b/tfexec/providers_lock.go
@@ -41,7 +41,7 @@ func (opt *ProviderOption) configureProvidersLock(conf *providersLockConfig) {
 }
 
 // ProvidersLock represents the `terraform providers lock` command
-func (tf *Terraform) ProvidersLock(ctx context.Context, opts ...ProvidersLockOption) error {
+func (tf *Tofu) ProvidersLock(ctx context.Context, opts ...ProvidersLockOption) error {
 	err := tf.compatible(ctx, tf0_14_0, nil)
 	if err != nil {
 		return fmt.Errorf("terraform providers lock was added in 0.14.0: %w", err)
@@ -57,7 +57,7 @@ func (tf *Terraform) ProvidersLock(ctx context.Context, opts ...ProvidersLockOpt
 	return err
 }
 
-func (tf *Terraform) providersLockCmd(ctx context.Context, opts ...ProvidersLockOption) *exec.Cmd {
+func (tf *Tofu) providersLockCmd(ctx context.Context, opts ...ProvidersLockOption) *exec.Cmd {
 	c := defaultProvidersLockOptions
 
 	for _, o := range opts {

--- a/tfexec/providers_lock.go
+++ b/tfexec/providers_lock.go
@@ -49,7 +49,7 @@ func (tf *Tofu) ProvidersLock(ctx context.Context, opts ...ProvidersLockOption) 
 
 	lockCmd := tf.providersLockCmd(ctx, opts...)
 
-	err = tf.runTerraformCmd(ctx, lockCmd)
+	err = tf.runTofuCmd(ctx, lockCmd)
 	if err != nil {
 		return err
 	}
@@ -83,5 +83,5 @@ func (tf *Tofu) providersLockCmd(ctx context.Context, opts ...ProvidersLockOptio
 		args = append(args, p)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTofuCmd(ctx, nil, args...)
 }

--- a/tfexec/providers_lock_test.go
+++ b/tfexec/providers_lock_test.go
@@ -15,7 +15,7 @@ import (
 func TestProvidersLockCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -17,7 +17,7 @@ func (tf *Tofu) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchemas, e
 	schemaCmd := tf.providersSchemaCmd(ctx)
 
 	var ret tfjson.ProviderSchemas
-	err := tf.runTerraformCmdJSON(ctx, schemaCmd, &ret)
+	err := tf.runTofuCmdJSON(ctx, schemaCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -34,5 +34,5 @@ func (tf *Tofu) providersSchemaCmd(ctx context.Context, args ...string) *exec.Cm
 	allArgs := []string{"providers", "schema", "-json", "-no-color"}
 	allArgs = append(allArgs, args...)
 
-	return tf.buildTerraformCmd(ctx, nil, allArgs...)
+	return tf.buildTofuCmd(ctx, nil, allArgs...)
 }

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ProvidersSchema represents the terraform providers schema -json subcommand.
-func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchemas, error) {
+func (tf *Tofu) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchemas, error) {
 	schemaCmd := tf.providersSchemaCmd(ctx)
 
 	var ret tfjson.ProviderSchemas
@@ -30,7 +30,7 @@ func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchem
 	return &ret, nil
 }
 
-func (tf *Terraform) providersSchemaCmd(ctx context.Context, args ...string) *exec.Cmd {
+func (tf *Tofu) providersSchemaCmd(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"providers", "schema", "-json", "-no-color"}
 	allArgs = append(allArgs, args...)
 

--- a/tfexec/providers_schema_test.go
+++ b/tfexec/providers_schema_test.go
@@ -15,7 +15,7 @@ import (
 func TestProvidersSchemaCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/refresh.go
+++ b/tfexec/refresh.go
@@ -77,7 +77,7 @@ func (opt *VarFileOption) configureRefresh(conf *refreshConfig) {
 }
 
 // Refresh represents the terraform refresh subcommand.
-func (tf *Terraform) Refresh(ctx context.Context, opts ...RefreshCmdOption) error {
+func (tf *Tofu) Refresh(ctx context.Context, opts ...RefreshCmdOption) error {
 	cmd, err := tf.refreshCmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func (tf *Terraform) Refresh(ctx context.Context, opts ...RefreshCmdOption) erro
 // [machine-readable](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)
 // JSON being written to the supplied `io.Writer`. RefreshJSON is likely to be
 // removed in a future major version in favour of Refresh returning JSON by default.
-func (tf *Terraform) RefreshJSON(ctx context.Context, w io.Writer, opts ...RefreshCmdOption) error {
+func (tf *Tofu) RefreshJSON(ctx context.Context, w io.Writer, opts ...RefreshCmdOption) error {
 	err := tf.compatible(ctx, tf0_15_3, nil)
 	if err != nil {
 		return fmt.Errorf("terraform refresh -json was added in 0.15.3: %w", err)
@@ -106,7 +106,7 @@ func (tf *Terraform) RefreshJSON(ctx context.Context, w io.Writer, opts ...Refre
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
 	c := defaultRefreshOptions
 
 	for _, o := range opts {
@@ -119,7 +119,7 @@ func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (
 
 }
 
-func (tf *Terraform) refreshJSONCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) refreshJSONCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
 	c := defaultRefreshOptions
 
 	for _, o := range opts {
@@ -132,7 +132,7 @@ func (tf *Terraform) refreshJSONCmd(ctx context.Context, opts ...RefreshCmdOptio
 	return tf.buildRefreshCmd(ctx, c, args)
 }
 
-func (tf *Terraform) buildRefreshArgs(c refreshConfig) []string {
+func (tf *Tofu) buildRefreshArgs(c refreshConfig) []string {
 	args := []string{"refresh", "-no-color", "-input=false"}
 
 	// string opts: only pass if set
@@ -170,7 +170,7 @@ func (tf *Terraform) buildRefreshArgs(c refreshConfig) []string {
 	return args
 }
 
-func (tf *Terraform) buildRefreshCmd(ctx context.Context, c refreshConfig, args []string) (*exec.Cmd, error) {
+func (tf *Tofu) buildRefreshCmd(ctx context.Context, c refreshConfig, args []string) (*exec.Cmd, error) {
 	// optional positional argument
 	if c.dir != "" {
 		args = append(args, c.dir)

--- a/tfexec/refresh.go
+++ b/tfexec/refresh.go
@@ -82,7 +82,7 @@ func (tf *Tofu) Refresh(ctx context.Context, opts ...RefreshCmdOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 // RefreshJSON represents the terraform refresh subcommand with the `-json` flag.
@@ -103,7 +103,7 @@ func (tf *Tofu) RefreshJSON(ctx context.Context, w io.Writer, opts ...RefreshCmd
 		return err
 	}
 
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
@@ -185,5 +185,5 @@ func (tf *Tofu) buildRefreshCmd(ctx context.Context, c refreshConfig, args []str
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/refresh_test.go
+++ b/tfexec/refresh_test.go
@@ -15,7 +15,7 @@ import (
 func TestRefreshCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestRefreshCmd(t *testing.T) {
 func TestRefreshJSONCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -55,7 +55,7 @@ func (tf *Tofu) Show(ctx context.Context, opts ...ShowOption) (*tfjson.State, er
 
 	var ret tfjson.State
 	ret.UseJSONNumber(true)
-	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
+	err = tf.runTofuCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (tf *Tofu) ShowStateFile(ctx context.Context, statePath string, opts ...Sho
 
 	var ret tfjson.State
 	ret.UseJSONNumber(true)
-	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
+	err = tf.runTofuCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (tf *Tofu) ShowPlanFile(ctx context.Context, planPath string, opts ...ShowO
 	showCmd := tf.showCmd(ctx, true, mergeEnv, planPath)
 
 	var ret tfjson.Plan
-	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
+	err = tf.runTofuCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (tf *Tofu) ShowPlanFileRaw(ctx context.Context, planPath string, opts ...Sh
 
 	var outBuf strings.Builder
 	showCmd.Stdout = &outBuf
-	err := tf.runTerraformCmd(ctx, showCmd)
+	err := tf.runTofuCmd(ctx, showCmd)
 	if err != nil {
 		return "", err
 	}
@@ -197,5 +197,5 @@ func (tf *Tofu) showCmd(ctx context.Context, jsonOutput bool, mergeEnv map[strin
 	allArgs = append(allArgs, "-no-color")
 	allArgs = append(allArgs, args...)
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, allArgs...)
+	return tf.buildTofuCmd(ctx, mergeEnv, allArgs...)
 }

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -30,7 +30,7 @@ func (opt *ReattachOption) configureShow(conf *showConfig) {
 
 // Show reads the default state path and outputs the state.
 // To read a state or plan file, ShowState or ShowPlan must be used instead.
-func (tf *Terraform) Show(ctx context.Context, opts ...ShowOption) (*tfjson.State, error) {
+func (tf *Tofu) Show(ctx context.Context, opts ...ShowOption) (*tfjson.State, error) {
 	err := tf.compatible(ctx, tf0_12_0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("terraform show -json was added in 0.12.0: %w", err)
@@ -69,7 +69,7 @@ func (tf *Terraform) Show(ctx context.Context, opts ...ShowOption) (*tfjson.Stat
 }
 
 // ShowStateFile reads a given state file and outputs the state.
-func (tf *Terraform) ShowStateFile(ctx context.Context, statePath string, opts ...ShowOption) (*tfjson.State, error) {
+func (tf *Tofu) ShowStateFile(ctx context.Context, statePath string, opts ...ShowOption) (*tfjson.State, error) {
 	err := tf.compatible(ctx, tf0_12_0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("terraform show -json was added in 0.12.0: %w", err)
@@ -112,7 +112,7 @@ func (tf *Terraform) ShowStateFile(ctx context.Context, statePath string, opts .
 }
 
 // ShowPlanFile reads a given plan file and outputs the plan.
-func (tf *Terraform) ShowPlanFile(ctx context.Context, planPath string, opts ...ShowOption) (*tfjson.Plan, error) {
+func (tf *Tofu) ShowPlanFile(ctx context.Context, planPath string, opts ...ShowOption) (*tfjson.Plan, error) {
 	err := tf.compatible(ctx, tf0_12_0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("terraform show -json was added in 0.12.0: %w", err)
@@ -156,7 +156,7 @@ func (tf *Terraform) ShowPlanFile(ctx context.Context, planPath string, opts ...
 
 // ShowPlanFileRaw reads a given plan file and outputs the plan in a
 // human-friendly, opaque format.
-func (tf *Terraform) ShowPlanFileRaw(ctx context.Context, planPath string, opts ...ShowOption) (string, error) {
+func (tf *Tofu) ShowPlanFileRaw(ctx context.Context, planPath string, opts ...ShowOption) (string, error) {
 	if planPath == "" {
 		return "", fmt.Errorf("planPath cannot be blank: use Show() if not passing planPath")
 	}
@@ -189,7 +189,7 @@ func (tf *Terraform) ShowPlanFileRaw(ctx context.Context, planPath string, opts 
 
 }
 
-func (tf *Terraform) showCmd(ctx context.Context, jsonOutput bool, mergeEnv map[string]string, args ...string) *exec.Cmd {
+func (tf *Tofu) showCmd(ctx context.Context, jsonOutput bool, mergeEnv map[string]string, args ...string) *exec.Cmd {
 	allArgs := []string{"show"}
 	if jsonOutput {
 		allArgs = append(allArgs, "-json")

--- a/tfexec/show_test.go
+++ b/tfexec/show_test.go
@@ -15,7 +15,7 @@ import (
 func TestShowCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestShowCmd(t *testing.T) {
 func TestShowStateFileCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestShowStateFileCmd(t *testing.T) {
 func TestShowPlanFileCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestShowPlanFileCmd(t *testing.T) {
 func TestShowPlanFileRawCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_mv.go
+++ b/tfexec/state_mv.go
@@ -65,7 +65,7 @@ func (tf *Tofu) StateMv(ctx context.Context, source string, destination string, 
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) stateMvCmd(ctx context.Context, source string, destination string, opts ...StateMvCmdOption) (*exec.Cmd, error) {
@@ -106,5 +106,5 @@ func (tf *Tofu) stateMvCmd(ctx context.Context, source string, destination strin
 	args = append(args, source)
 	args = append(args, destination)
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/state_mv.go
+++ b/tfexec/state_mv.go
@@ -60,7 +60,7 @@ func (opt *StateOutOption) configureStateMv(conf *stateMvConfig) {
 }
 
 // StateMv represents the terraform state mv subcommand.
-func (tf *Terraform) StateMv(ctx context.Context, source string, destination string, opts ...StateMvCmdOption) error {
+func (tf *Tofu) StateMv(ctx context.Context, source string, destination string, opts ...StateMvCmdOption) error {
 	cmd, err := tf.stateMvCmd(ctx, source, destination, opts...)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (tf *Terraform) StateMv(ctx context.Context, source string, destination str
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) stateMvCmd(ctx context.Context, source string, destination string, opts ...StateMvCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) stateMvCmd(ctx context.Context, source string, destination string, opts ...StateMvCmdOption) (*exec.Cmd, error) {
 	c := defaultStateMvOptions
 
 	for _, o := range opts {

--- a/tfexec/state_mv_test.go
+++ b/tfexec/state_mv_test.go
@@ -15,7 +15,7 @@ import (
 func TestStateMvCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_pull.go
+++ b/tfexec/state_pull.go
@@ -25,7 +25,7 @@ func (opt *ReattachOption) configureStatePull(conf *statePullConfig) {
 	conf.reattachInfo = opt.info
 }
 
-func (tf *Terraform) StatePull(ctx context.Context, opts ...StatePullOption) (string, error) {
+func (tf *Tofu) StatePull(ctx context.Context, opts ...StatePullOption) (string, error) {
 	c := defaultStatePullConfig
 
 	for _, o := range opts {
@@ -53,7 +53,7 @@ func (tf *Terraform) StatePull(ctx context.Context, opts ...StatePullOption) (st
 	return ret.String(), nil
 }
 
-func (tf *Terraform) statePullCmd(ctx context.Context, mergeEnv map[string]string) *exec.Cmd {
+func (tf *Tofu) statePullCmd(ctx context.Context, mergeEnv map[string]string) *exec.Cmd {
 	args := []string{"state", "pull"}
 
 	return tf.buildTerraformCmd(ctx, mergeEnv, args...)

--- a/tfexec/state_pull.go
+++ b/tfexec/state_pull.go
@@ -45,7 +45,7 @@ func (tf *Tofu) StatePull(ctx context.Context, opts ...StatePullOption) (string,
 
 	var ret bytes.Buffer
 	cmd.Stdout = &ret
-	err := tf.runTerraformCmd(ctx, cmd)
+	err := tf.runTofuCmd(ctx, cmd)
 	if err != nil {
 		return "", err
 	}
@@ -56,5 +56,5 @@ func (tf *Tofu) StatePull(ctx context.Context, opts ...StatePullOption) (string,
 func (tf *Tofu) statePullCmd(ctx context.Context, mergeEnv map[string]string) *exec.Cmd {
 	args := []string{"state", "pull"}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...)
+	return tf.buildTofuCmd(ctx, mergeEnv, args...)
 }

--- a/tfexec/state_pull_test.go
+++ b/tfexec/state_pull_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestStatePull(t *testing.T) {
-	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(t.TempDir(), tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_push.go
+++ b/tfexec/state_push.go
@@ -39,7 +39,7 @@ func (opt *LockTimeoutOption) configureStatePush(conf *statePushConfig) {
 	conf.lockTimeout = opt.timeout
 }
 
-func (tf *Terraform) StatePush(ctx context.Context, path string, opts ...StatePushCmdOption) error {
+func (tf *Tofu) StatePush(ctx context.Context, path string, opts ...StatePushCmdOption) error {
 	cmd, err := tf.statePushCmd(ctx, path, opts...)
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func (tf *Terraform) StatePush(ctx context.Context, path string, opts ...StatePu
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) statePushCmd(ctx context.Context, path string, opts ...StatePushCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) statePushCmd(ctx context.Context, path string, opts ...StatePushCmdOption) (*exec.Cmd, error) {
 	c := defaultStatePushOptions
 
 	for _, o := range opts {

--- a/tfexec/state_push.go
+++ b/tfexec/state_push.go
@@ -44,7 +44,7 @@ func (tf *Tofu) StatePush(ctx context.Context, path string, opts ...StatePushCmd
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) statePushCmd(ctx context.Context, path string, opts ...StatePushCmdOption) (*exec.Cmd, error) {
@@ -68,5 +68,5 @@ func (tf *Tofu) statePushCmd(ctx context.Context, path string, opts ...StatePush
 
 	args = append(args, path)
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/state_push_test.go
+++ b/tfexec/state_push_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestStatePushCmd(t *testing.T) {
-	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(t.TempDir(), tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_rm.go
+++ b/tfexec/state_rm.go
@@ -60,7 +60,7 @@ func (opt *StateOutOption) configureStateRm(conf *stateRmConfig) {
 }
 
 // StateRm represents the terraform state rm subcommand.
-func (tf *Terraform) StateRm(ctx context.Context, address string, opts ...StateRmCmdOption) error {
+func (tf *Tofu) StateRm(ctx context.Context, address string, opts ...StateRmCmdOption) error {
 	cmd, err := tf.stateRmCmd(ctx, address, opts...)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (tf *Terraform) StateRm(ctx context.Context, address string, opts ...StateR
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) stateRmCmd(ctx context.Context, address string, opts ...StateRmCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) stateRmCmd(ctx context.Context, address string, opts ...StateRmCmdOption) (*exec.Cmd, error) {
 	c := defaultStateRmOptions
 
 	for _, o := range opts {

--- a/tfexec/state_rm.go
+++ b/tfexec/state_rm.go
@@ -65,7 +65,7 @@ func (tf *Tofu) StateRm(ctx context.Context, address string, opts ...StateRmCmdO
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) stateRmCmd(ctx context.Context, address string, opts ...StateRmCmdOption) (*exec.Cmd, error) {
@@ -105,5 +105,5 @@ func (tf *Tofu) stateRmCmd(ctx context.Context, address string, opts ...StateRmC
 	// positional arguments
 	args = append(args, address)
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTofuCmd(ctx, nil, args...), nil
 }

--- a/tfexec/state_rm_test.go
+++ b/tfexec/state_rm_test.go
@@ -15,7 +15,7 @@ import (
 func TestStateRmCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/taint.go
+++ b/tfexec/taint.go
@@ -52,7 +52,7 @@ func (tf *Tofu) Taint(ctx context.Context, address string, opts ...TaintOption) 
 		return fmt.Errorf("taint was first introduced in Terraform 0.4.1: %w", err)
 	}
 	taintCmd := tf.taintCmd(ctx, address, opts...)
-	return tf.runTerraformCmd(ctx, taintCmd)
+	return tf.runTofuCmd(ctx, taintCmd)
 }
 
 func (tf *Tofu) taintCmd(ctx context.Context, address string, opts ...TaintOption) *exec.Cmd {
@@ -79,5 +79,5 @@ func (tf *Tofu) taintCmd(ctx context.Context, address string, opts ...TaintOptio
 	}
 	args = append(args, address)
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTofuCmd(ctx, nil, args...)
 }

--- a/tfexec/taint.go
+++ b/tfexec/taint.go
@@ -46,7 +46,7 @@ func (opt *LockTimeoutOption) configureTaint(conf *taintConfig) {
 }
 
 // Taint represents the terraform taint subcommand.
-func (tf *Terraform) Taint(ctx context.Context, address string, opts ...TaintOption) error {
+func (tf *Tofu) Taint(ctx context.Context, address string, opts ...TaintOption) error {
 	err := tf.compatible(ctx, tf0_4_1, nil)
 	if err != nil {
 		return fmt.Errorf("taint was first introduced in Terraform 0.4.1: %w", err)
@@ -55,7 +55,7 @@ func (tf *Terraform) Taint(ctx context.Context, address string, opts ...TaintOpt
 	return tf.runTerraformCmd(ctx, taintCmd)
 }
 
-func (tf *Terraform) taintCmd(ctx context.Context, address string, opts ...TaintOption) *exec.Cmd {
+func (tf *Tofu) taintCmd(ctx context.Context, address string, opts ...TaintOption) *exec.Cmd {
 	c := defaultTaintOptions
 
 	for _, o := range opts {

--- a/tfexec/taint_test.go
+++ b/tfexec/taint_test.go
@@ -15,7 +15,7 @@ import (
 func TestTaintCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -21,9 +21,9 @@ type printfer interface {
 	Printf(format string, v ...interface{})
 }
 
-// Terraform represents the Terraform CLI executable and working directory.
+// Tofu represents the Tofu CLI executable and working directory.
 //
-// Typically this is constructed against the root module of a Terraform configuration
+// Typically this is constructed against the root module of a Tofu configuration
 // but you can override paths used in some commands depending on the available
 // options.
 //
@@ -45,7 +45,7 @@ type printfer interface {
 //   - TF_REATTACH_PROVIDERS
 //   - TF_DISABLE_PLUGIN_TLS
 //   - TF_SKIP_PROVIDER_VERIFY
-type Terraform struct {
+type Tofu struct {
 	execPath           string
 	workingDir         string
 	appendUserAgent    string
@@ -77,7 +77,7 @@ type Terraform struct {
 // NewTerraform returns a Terraform struct with default values for all fields.
 // If a blank execPath is supplied, NewTerraform will error.
 // Use hc-install or output from os.LookPath to get a desirable execPath.
-func NewTerraform(workingDir string, execPath string) (*Terraform, error) {
+func NewTerraform(workingDir string, execPath string) (*Tofu, error) {
 	if workingDir == "" {
 		return nil, fmt.Errorf("Terraform cannot be initialised with empty workdir")
 	}
@@ -92,7 +92,7 @@ func NewTerraform(workingDir string, execPath string) (*Terraform, error) {
 			err: err,
 		}
 	}
-	tf := Terraform{
+	tf := Tofu{
 		execPath:   execPath,
 		workingDir: workingDir,
 		env:        nil, // explicit nil means copy os.Environ
@@ -106,7 +106,7 @@ func NewTerraform(workingDir string, execPath string) (*Terraform, error) {
 // Terraform environment variables that are already covered in options. Pass nil to copy the values
 // from os.Environ. Attempting to set environment variables that should be managed manually will
 // result in ErrManualEnvVar being returned.
-func (tf *Terraform) SetEnv(env map[string]string) error {
+func (tf *Tofu) SetEnv(env map[string]string) error {
 	prohibited := ProhibitedEnv(env)
 	if len(prohibited) > 0 {
 		// just error on the first instance
@@ -118,7 +118,7 @@ func (tf *Terraform) SetEnv(env map[string]string) error {
 }
 
 // SetLogger specifies a logger for tfexec to use.
-func (tf *Terraform) SetLogger(logger printfer) {
+func (tf *Tofu) SetLogger(logger printfer) {
 	tf.logger = logger
 }
 
@@ -126,7 +126,7 @@ func (tf *Terraform) SetLogger(logger printfer) {
 //
 // This should be used for information or logging purposes only, not control
 // flow. Any parsing necessary should be added as functionality to this package.
-func (tf *Terraform) SetStdout(w io.Writer) {
+func (tf *Tofu) SetStdout(w io.Writer) {
 	tf.stdout = w
 }
 
@@ -134,7 +134,7 @@ func (tf *Terraform) SetStdout(w io.Writer) {
 //
 // This should be used for information or logging purposes only, not control
 // flow. Any parsing necessary should be added as functionality to this package.
-func (tf *Terraform) SetStderr(w io.Writer) {
+func (tf *Tofu) SetStderr(w io.Writer) {
 	tf.stderr = w
 }
 
@@ -146,7 +146,7 @@ func (tf *Terraform) SetStderr(w io.Writer) {
 // SetLogPath is called on versions 0.14.11 and earlier, or if SetLogCore and
 // SetLogProvider have not been called before SetLogPath on versions 0.15.0 and
 // later.
-func (tf *Terraform) SetLog(log string) error {
+func (tf *Tofu) SetLog(log string) error {
 	err := tf.compatible(context.Background(), tf0_15_0, nil)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (tf *Terraform) SetLog(log string) error {
 // execution. This must be combined with a call to SetLogPath to take effect.
 //
 // This is only compatible with Terraform CLI 0.15.0 or later.
-func (tf *Terraform) SetLogCore(logCore string) error {
+func (tf *Tofu) SetLogCore(logCore string) error {
 	err := tf.compatible(context.Background(), tf0_15_0, nil)
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func (tf *Terraform) SetLogCore(logCore string) error {
 
 // SetLogPath sets the TF_LOG_PATH environment variable for Terraform CLI
 // execution.
-func (tf *Terraform) SetLogPath(path string) error {
+func (tf *Tofu) SetLogPath(path string) error {
 	tf.logPath = path
 	// Prevent setting the log path without enabling logging
 	if tf.log == "" && tf.logCore == "" && tf.logProvider == "" {
@@ -184,7 +184,7 @@ func (tf *Terraform) SetLogPath(path string) error {
 // effect.
 //
 // This is only compatible with Terraform CLI 0.15.0 or later.
-func (tf *Terraform) SetLogProvider(logProvider string) error {
+func (tf *Tofu) SetLogProvider(logProvider string) error {
 	err := tf.compatible(context.Background(), tf0_15_0, nil)
 	if err != nil {
 		return err
@@ -195,21 +195,21 @@ func (tf *Terraform) SetLogProvider(logProvider string) error {
 
 // SetAppendUserAgent sets the TF_APPEND_USER_AGENT environment variable for
 // Terraform CLI execution.
-func (tf *Terraform) SetAppendUserAgent(ua string) error {
+func (tf *Tofu) SetAppendUserAgent(ua string) error {
 	tf.appendUserAgent = ua
 	return nil
 }
 
 // SetDisablePluginTLS sets the TF_DISABLE_PLUGIN_TLS environment variable for
 // Terraform CLI execution.
-func (tf *Terraform) SetDisablePluginTLS(disabled bool) error {
+func (tf *Tofu) SetDisablePluginTLS(disabled bool) error {
 	tf.disablePluginTLS = disabled
 	return nil
 }
 
 // SetSkipProviderVerify sets the TF_SKIP_PROVIDER_VERIFY environment variable
 // for Terraform CLI execution. This is no longer used in 0.13.0 and greater.
-func (tf *Terraform) SetSkipProviderVerify(skip bool) error {
+func (tf *Tofu) SetSkipProviderVerify(skip bool) error {
 	err := tf.compatible(context.Background(), nil, tf0_13_0)
 	if err != nil {
 		return err
@@ -219,11 +219,11 @@ func (tf *Terraform) SetSkipProviderVerify(skip bool) error {
 }
 
 // WorkingDir returns the working directory for Terraform.
-func (tf *Terraform) WorkingDir() string {
+func (tf *Tofu) WorkingDir() string {
 	return tf.workingDir
 }
 
 // ExecPath returns the path to the Terraform executable.
-func (tf *Terraform) ExecPath() string {
+func (tf *Tofu) ExecPath() string {
 	return tf.execPath
 }

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -74,10 +74,10 @@ type Tofu struct {
 	provVersions map[string]*version.Version
 }
 
-// NewTerraform returns a Terraform struct with default values for all fields.
-// If a blank execPath is supplied, NewTerraform will error.
+// NewTofu returns a Terraform struct with default values for all fields.
+// If a blank execPath is supplied, NewTofu will error.
 // Use hc-install or output from os.LookPath to get a desirable execPath.
-func NewTerraform(workingDir string, execPath string) (*Tofu, error) {
+func NewTofu(workingDir string, execPath string) (*Tofu, error) {
 	if workingDir == "" {
 		return nil, fmt.Errorf("Terraform cannot be initialised with empty workdir")
 	}

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 func TestSetEnv(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestSetEnv(t *testing.T) {
 func TestSetLog(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 
 	if err != nil {
 		t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -93,7 +93,7 @@ func TestSetLog(t *testing.T) {
 
 		td012 := t.TempDir()
 
-		tf012, err := NewTerraform(td012, tfVersion(t, testutil.Latest012))
+		tf012, err := NewTofu(td012, tfVersion(t, testutil.Latest012))
 
 		if err != nil {
 			t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -213,7 +213,7 @@ func TestSetLog(t *testing.T) {
 func TestSetLogCore(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 
 	if err != nil {
 		t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -235,7 +235,7 @@ func TestSetLogCore(t *testing.T) {
 
 		td012 := t.TempDir()
 
-		tf012, err := NewTerraform(td012, tfVersion(t, testutil.Latest012))
+		tf012, err := NewTofu(td012, tfVersion(t, testutil.Latest012))
 
 		if err != nil {
 			t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -355,7 +355,7 @@ func TestSetLogCore(t *testing.T) {
 func TestSetLogPath(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 
 	if err != nil {
 		t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -526,7 +526,7 @@ func TestSetLogPath(t *testing.T) {
 func TestSetLogProvider(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 
 	if err != nil {
 		t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -548,7 +548,7 @@ func TestSetLogProvider(t *testing.T) {
 
 		td012 := t.TempDir()
 
-		tf012, err := NewTerraform(td012, tfVersion(t, testutil.Latest012))
+		tf012, err := NewTofu(td012, tfVersion(t, testutil.Latest012))
 
 		if err != nil {
 			t.Fatalf("unexpected NewTerraform error: %s", err)
@@ -672,7 +672,7 @@ func TestCheckpointDisablePropagation_v012(t *testing.T) {
 
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest012))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -749,7 +749,7 @@ func TestCheckpointDisablePropagation_v012(t *testing.T) {
 func TestCheckpointDisablePropagation_v1(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -820,7 +820,7 @@ func TestCheckpointDisablePropagation_v1(t *testing.T) {
 func TestNoTerraformBinary(t *testing.T) {
 	td := t.TempDir()
 
-	_, err := NewTerraform(td, "")
+	_, err := NewTofu(td, "")
 	if err == nil {
 		t.Fatal("expected NewTerraform to error, but it did not")
 	}

--- a/tfexec/test.go
+++ b/tfexec/test.go
@@ -42,7 +42,7 @@ func (tf *Tofu) Test(ctx context.Context, w io.Writer, opts ...TestOption) error
 
 	testCmd := tf.testCmd(ctx)
 
-	err = tf.runTerraformCmd(ctx, testCmd)
+	err = tf.runTofuCmd(ctx, testCmd)
 
 	if err != nil {
 		return err
@@ -64,5 +64,5 @@ func (tf *Tofu) testCmd(ctx context.Context, opts ...TestOption) *exec.Cmd {
 		args = append(args, "-tests-directory="+c.testsDirectory)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTofuCmd(ctx, nil, args...)
 }

--- a/tfexec/test.go
+++ b/tfexec/test.go
@@ -31,7 +31,7 @@ func (opt *TestsDirectoryOption) configureTest(conf *testConfig) {
 // The given io.Writer, if specified, will receive
 // [machine-readable](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)
 // JSON from Terraform including test results.
-func (tf *Terraform) Test(ctx context.Context, w io.Writer, opts ...TestOption) error {
+func (tf *Tofu) Test(ctx context.Context, w io.Writer, opts ...TestOption) error {
 	err := tf.compatible(ctx, tf1_6_0, nil)
 
 	if err != nil {
@@ -51,7 +51,7 @@ func (tf *Terraform) Test(ctx context.Context, w io.Writer, opts ...TestOption) 
 	return nil
 }
 
-func (tf *Terraform) testCmd(ctx context.Context, opts ...TestOption) *exec.Cmd {
+func (tf *Tofu) testCmd(ctx context.Context, opts ...TestOption) *exec.Cmd {
 	c := defaultTestOptions
 
 	for _, o := range opts {

--- a/tfexec/test_test.go
+++ b/tfexec/test_test.go
@@ -15,7 +15,7 @@ import (
 func TestTestCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_6))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1_6))
 
 	if err != nil {
 		t.Fatal(err)

--- a/tfexec/untaint.go
+++ b/tfexec/untaint.go
@@ -52,7 +52,7 @@ func (tf *Tofu) Untaint(ctx context.Context, address string, opts ...UntaintOpti
 		return fmt.Errorf("untaint was first introduced in Terraform 0.6.13: %w", err)
 	}
 	untaintCmd := tf.untaintCmd(ctx, address, opts...)
-	return tf.runTerraformCmd(ctx, untaintCmd)
+	return tf.runTofuCmd(ctx, untaintCmd)
 }
 
 func (tf *Tofu) untaintCmd(ctx context.Context, address string, opts ...UntaintOption) *exec.Cmd {
@@ -79,5 +79,5 @@ func (tf *Tofu) untaintCmd(ctx context.Context, address string, opts ...UntaintO
 	}
 	args = append(args, address)
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTofuCmd(ctx, nil, args...)
 }

--- a/tfexec/untaint.go
+++ b/tfexec/untaint.go
@@ -46,7 +46,7 @@ func (opt *LockTimeoutOption) configureUntaint(conf *untaintConfig) {
 }
 
 // Untaint represents the terraform untaint subcommand.
-func (tf *Terraform) Untaint(ctx context.Context, address string, opts ...UntaintOption) error {
+func (tf *Tofu) Untaint(ctx context.Context, address string, opts ...UntaintOption) error {
 	err := tf.compatible(ctx, tf0_6_13, nil)
 	if err != nil {
 		return fmt.Errorf("untaint was first introduced in Terraform 0.6.13: %w", err)
@@ -55,7 +55,7 @@ func (tf *Terraform) Untaint(ctx context.Context, address string, opts ...Untain
 	return tf.runTerraformCmd(ctx, untaintCmd)
 }
 
-func (tf *Terraform) untaintCmd(ctx context.Context, address string, opts ...UntaintOption) *exec.Cmd {
+func (tf *Tofu) untaintCmd(ctx context.Context, address string, opts ...UntaintOption) *exec.Cmd {
 	c := defaultUntaintOptions
 
 	for _, o := range opts {

--- a/tfexec/untaint_test.go
+++ b/tfexec/untaint_test.go
@@ -15,7 +15,7 @@ import (
 func TestUntaintCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/upgrade012.go
+++ b/tfexec/upgrade012.go
@@ -45,7 +45,7 @@ func (tf *Tofu) Upgrade012(ctx context.Context, opts ...Upgrade012Option) error 
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) upgrade012Cmd(ctx context.Context, opts ...Upgrade012Option) (*exec.Cmd, error) {
@@ -81,5 +81,5 @@ func (tf *Tofu) upgrade012Cmd(ctx context.Context, opts ...Upgrade012Option) (*e
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/upgrade012.go
+++ b/tfexec/upgrade012.go
@@ -40,7 +40,7 @@ func (opt *ReattachOption) configureUpgrade012(conf *upgrade012Config) {
 }
 
 // Upgrade012 represents the terraform 0.12upgrade subcommand.
-func (tf *Terraform) Upgrade012(ctx context.Context, opts ...Upgrade012Option) error {
+func (tf *Tofu) Upgrade012(ctx context.Context, opts ...Upgrade012Option) error {
 	cmd, err := tf.upgrade012Cmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (tf *Terraform) Upgrade012(ctx context.Context, opts ...Upgrade012Option) e
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) upgrade012Cmd(ctx context.Context, opts ...Upgrade012Option) (*exec.Cmd, error) {
+func (tf *Tofu) upgrade012Cmd(ctx context.Context, opts ...Upgrade012Option) (*exec.Cmd, error) {
 	err := tf.compatible(ctx, tf0_12_0, tf0_13_0)
 	if err != nil {
 		return nil, fmt.Errorf("terraform 0.12upgrade is only supported in 0.12 releases: %w", err)

--- a/tfexec/upgrade012_test.go
+++ b/tfexec/upgrade012_test.go
@@ -23,7 +23,7 @@ func TestUpgrade012(t *testing.T) {
 	td := t.TempDir()
 
 	t.Run("defaults", func(t *testing.T) {
-		tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+		tf, err := NewTofu(td, tfVersion(t, testutil.Latest012))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -44,7 +44,7 @@ func TestUpgrade012(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+		tf, err := NewTofu(td, tfVersion(t, testutil.Latest012))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +72,7 @@ func TestUpgrade012(t *testing.T) {
 	}
 	for _, tfv := range unsupportedVersions {
 		t.Run(fmt.Sprintf("unsupported on %s", tfv), func(t *testing.T) {
-			tf, err := NewTerraform(td, tfVersion(t, tfv))
+			tf, err := NewTofu(td, tfVersion(t, tfv))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tfexec/upgrade013.go
+++ b/tfexec/upgrade013.go
@@ -33,7 +33,7 @@ func (opt *ReattachOption) configureUpgrade013(conf *upgrade013Config) {
 }
 
 // Upgrade013 represents the terraform 0.13upgrade subcommand.
-func (tf *Terraform) Upgrade013(ctx context.Context, opts ...Upgrade013Option) error {
+func (tf *Tofu) Upgrade013(ctx context.Context, opts ...Upgrade013Option) error {
 	cmd, err := tf.upgrade013Cmd(ctx, opts...)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (tf *Terraform) Upgrade013(ctx context.Context, opts ...Upgrade013Option) e
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) upgrade013Cmd(ctx context.Context, opts ...Upgrade013Option) (*exec.Cmd, error) {
+func (tf *Tofu) upgrade013Cmd(ctx context.Context, opts ...Upgrade013Option) (*exec.Cmd, error) {
 	err := tf.compatible(ctx, tf0_13_0, tf0_14_0)
 	if err != nil {
 		return nil, fmt.Errorf("terraform 0.13upgrade is only supported in 0.13 releases: %w", err)

--- a/tfexec/upgrade013.go
+++ b/tfexec/upgrade013.go
@@ -38,7 +38,7 @@ func (tf *Tofu) Upgrade013(ctx context.Context, opts ...Upgrade013Option) error 
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) upgrade013Cmd(ctx context.Context, opts ...Upgrade013Option) (*exec.Cmd, error) {
@@ -69,5 +69,5 @@ func (tf *Tofu) upgrade013Cmd(ctx context.Context, opts ...Upgrade013Option) (*e
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTofuCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/upgrade013_test.go
+++ b/tfexec/upgrade013_test.go
@@ -23,7 +23,7 @@ func TestUpgrade013(t *testing.T) {
 	td := t.TempDir()
 
 	t.Run("defaults", func(t *testing.T) {
-		tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+		tf, err := NewTofu(td, tfVersion(t, testutil.Latest013))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -44,7 +44,7 @@ func TestUpgrade013(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+		tf, err := NewTofu(td, tfVersion(t, testutil.Latest013))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +73,7 @@ func TestUpgrade013(t *testing.T) {
 	}
 	for _, tfv := range unsupportedVersions {
 		t.Run(fmt.Sprintf("unsupported on %s", tfv), func(t *testing.T) {
-			tf, err := NewTerraform(td, tfVersion(t, tfv))
+			tf, err := NewTofu(td, tfVersion(t, tfv))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tfexec/validate.go
+++ b/tfexec/validate.go
@@ -22,12 +22,12 @@ func (tf *Tofu) Validate(ctx context.Context) (*tfjson.ValidateOutput, error) {
 		return nil, fmt.Errorf("terraform validate -json was added in 0.12.0: %w", err)
 	}
 
-	cmd := tf.buildTerraformCmd(ctx, nil, "validate", "-no-color", "-json")
+	cmd := tf.buildTofuCmd(ctx, nil, "validate", "-no-color", "-json")
 
 	var outBuf = bytes.Buffer{}
 	cmd.Stdout = &outBuf
 
-	err = tf.runTerraformCmd(ctx, cmd)
+	err = tf.runTofuCmd(ctx, cmd)
 	// TODO: this command should not exit 1 if you pass -json as its hard to differentiate other errors
 	if err != nil && cmd.ProcessState.ExitCode() != 1 {
 		return nil, err

--- a/tfexec/validate.go
+++ b/tfexec/validate.go
@@ -16,7 +16,7 @@ import (
 
 // Validate represents the validate subcommand to the Terraform CLI. The -json
 // flag support was added in 0.12.0, so this will not work on earlier versions.
-func (tf *Terraform) Validate(ctx context.Context) (*tfjson.ValidateOutput, error) {
+func (tf *Tofu) Validate(ctx context.Context) (*tfjson.ValidateOutput, error) {
 	err := tf.compatible(ctx, tf0_12_0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("terraform validate -json was added in 0.12.0: %w", err)

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -56,12 +56,12 @@ func (tf *Tofu) Version(ctx context.Context, skipCache bool) (tfVersion *version
 
 // version does not use the locking on the Terraform instance and should probably not be used directly, prefer Version.
 func (tf *Tofu) version(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
-	versionCmd := tf.buildTerraformCmd(ctx, nil, "version", "-json")
+	versionCmd := tf.buildTofuCmd(ctx, nil, "version", "-json")
 
 	var outBuf bytes.Buffer
 	versionCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(ctx, versionCmd)
+	err := tf.runTofuCmd(ctx, versionCmd)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,12 +102,12 @@ func parseJsonVersionOutput(stdout []byte) (*version.Version, map[string]*versio
 }
 
 func (tf *Tofu) versionFromPlaintext(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
-	versionCmd := tf.buildTerraformCmd(ctx, nil, "version")
+	versionCmd := tf.buildTofuCmd(ctx, nil, "version")
 
 	var outBuf strings.Builder
 	versionCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(ctx, versionCmd)
+	err := tf.runTofuCmd(ctx, versionCmd)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -40,7 +40,7 @@ var (
 // Version returns structured output from the terraform version command including both the Terraform CLI version
 // and any initialized provider versions. This will read cached values when present unless the skipCache parameter
 // is set to true.
-func (tf *Terraform) Version(ctx context.Context, skipCache bool) (tfVersion *version.Version, providerVersions map[string]*version.Version, err error) {
+func (tf *Tofu) Version(ctx context.Context, skipCache bool) (tfVersion *version.Version, providerVersions map[string]*version.Version, err error) {
 	tf.versionLock.Lock()
 	defer tf.versionLock.Unlock()
 
@@ -55,7 +55,7 @@ func (tf *Terraform) Version(ctx context.Context, skipCache bool) (tfVersion *ve
 }
 
 // version does not use the locking on the Terraform instance and should probably not be used directly, prefer Version.
-func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
+func (tf *Tofu) version(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
 	versionCmd := tf.buildTerraformCmd(ctx, nil, "version", "-json")
 
 	var outBuf bytes.Buffer
@@ -101,7 +101,7 @@ func parseJsonVersionOutput(stdout []byte) (*version.Version, map[string]*versio
 	return tfVersion, providerVersions, nil
 }
 
-func (tf *Terraform) versionFromPlaintext(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
+func (tf *Tofu) versionFromPlaintext(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
 	versionCmd := tf.buildTerraformCmd(ctx, nil, "version")
 
 	var outBuf strings.Builder
@@ -166,7 +166,7 @@ func errorVersionString(v *version.Version) string {
 }
 
 // compatible asserts compatibility of the cached terraform version with the executable, and returns a well known error if not.
-func (tf *Terraform) compatible(ctx context.Context, minInclusive *version.Version, maxExclusive *version.Version) error {
+func (tf *Tofu) compatible(ctx context.Context, minInclusive *version.Version, maxExclusive *version.Version) error {
 	tfv, _, err := tf.Version(ctx, false)
 	if err != nil {
 		return err

--- a/tfexec/version_test.go
+++ b/tfexec/version_test.go
@@ -262,7 +262,7 @@ func TestCompatible(t *testing.T) {
 		{true, "", "0.14.0", tf013beta3},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			tf, err := NewTerraform(filepath.Dir(c.binPath), c.binPath)
+			tf, err := NewTofu(filepath.Dir(c.binPath), c.binPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tfexec/workspace_delete.go
+++ b/tfexec/workspace_delete.go
@@ -41,7 +41,7 @@ func (opt *ForceOption) configureWorkspaceDelete(conf *workspaceDeleteConfig) {
 }
 
 // WorkspaceDelete represents the workspace delete subcommand to the Terraform CLI.
-func (tf *Terraform) WorkspaceDelete(ctx context.Context, workspace string, opts ...WorkspaceDeleteCmdOption) error {
+func (tf *Tofu) WorkspaceDelete(ctx context.Context, workspace string, opts ...WorkspaceDeleteCmdOption) error {
 	cmd, err := tf.workspaceDeleteCmd(ctx, workspace, opts...)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (tf *Terraform) WorkspaceDelete(ctx context.Context, workspace string, opts
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) workspaceDeleteCmd(ctx context.Context, workspace string, opts ...WorkspaceDeleteCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) workspaceDeleteCmd(ctx context.Context, workspace string, opts ...WorkspaceDeleteCmdOption) (*exec.Cmd, error) {
 	c := defaultWorkspaceDeleteOptions
 
 	for _, o := range opts {

--- a/tfexec/workspace_delete.go
+++ b/tfexec/workspace_delete.go
@@ -46,7 +46,7 @@ func (tf *Tofu) WorkspaceDelete(ctx context.Context, workspace string, opts ...W
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) workspaceDeleteCmd(ctx context.Context, workspace string, opts ...WorkspaceDeleteCmdOption) (*exec.Cmd, error) {
@@ -80,7 +80,7 @@ func (tf *Tofu) workspaceDeleteCmd(ctx context.Context, workspace string, opts .
 
 	args = append(args, workspace)
 
-	cmd := tf.buildTerraformCmd(ctx, nil, args...)
+	cmd := tf.buildTofuCmd(ctx, nil, args...)
 
 	return cmd, nil
 }

--- a/tfexec/workspace_delete_test.go
+++ b/tfexec/workspace_delete_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWorkspaceDeleteCmd(t *testing.T) {
-	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(t.TempDir(), tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -13,12 +13,12 @@ import (
 // WorkspaceList represents the workspace list subcommand to the Terraform CLI.
 func (tf *Tofu) WorkspaceList(ctx context.Context) ([]string, string, error) {
 	// TODO: [DIR] param option
-	wlCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "list", "-no-color")
+	wlCmd := tf.buildTofuCmd(ctx, nil, "workspace", "list", "-no-color")
 
 	var outBuf strings.Builder
 	wlCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(ctx, wlCmd)
+	err := tf.runTofuCmd(ctx, wlCmd)
 	if err != nil {
 		return nil, "", err
 	}

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 // WorkspaceList represents the workspace list subcommand to the Terraform CLI.
-func (tf *Terraform) WorkspaceList(ctx context.Context) ([]string, string, error) {
+func (tf *Tofu) WorkspaceList(ctx context.Context) ([]string, string, error) {
 	// TODO: [DIR] param option
 	wlCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "list", "-no-color")
 

--- a/tfexec/workspace_new.go
+++ b/tfexec/workspace_new.go
@@ -46,7 +46,7 @@ func (tf *Tofu) WorkspaceNew(ctx context.Context, workspace string, opts ...Work
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(ctx, cmd)
+	return tf.runTofuCmd(ctx, cmd)
 }
 
 func (tf *Tofu) workspaceNewCmd(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) (*exec.Cmd, error) {
@@ -82,7 +82,7 @@ func (tf *Tofu) workspaceNewCmd(ctx context.Context, workspace string, opts ...W
 
 	args = append(args, workspace)
 
-	cmd := tf.buildTerraformCmd(ctx, nil, args...)
+	cmd := tf.buildTofuCmd(ctx, nil, args...)
 
 	return cmd, nil
 }

--- a/tfexec/workspace_new.go
+++ b/tfexec/workspace_new.go
@@ -41,7 +41,7 @@ func (opt *CopyStateOption) configureWorkspaceNew(conf *workspaceNewConfig) {
 }
 
 // WorkspaceNew represents the workspace new subcommand to the Terraform CLI.
-func (tf *Terraform) WorkspaceNew(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) error {
+func (tf *Tofu) WorkspaceNew(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) error {
 	cmd, err := tf.workspaceNewCmd(ctx, workspace, opts...)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (tf *Terraform) WorkspaceNew(ctx context.Context, workspace string, opts ..
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) workspaceNewCmd(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) (*exec.Cmd, error) {
+func (tf *Tofu) workspaceNewCmd(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) (*exec.Cmd, error) {
 	// TODO: [DIR] param option
 
 	c := defaultWorkspaceNewOptions

--- a/tfexec/workspace_new_test.go
+++ b/tfexec/workspace_new_test.go
@@ -16,7 +16,7 @@ import (
 func TestWorkspaceNewCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/workspace_select.go
+++ b/tfexec/workspace_select.go
@@ -8,7 +8,7 @@ package tfexec
 import "context"
 
 // WorkspaceSelect represents the workspace select subcommand to the Terraform CLI.
-func (tf *Terraform) WorkspaceSelect(ctx context.Context, workspace string) error {
+func (tf *Tofu) WorkspaceSelect(ctx context.Context, workspace string) error {
 	// TODO: [DIR] param option
 
 	return tf.runTerraformCmd(ctx, tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))

--- a/tfexec/workspace_select.go
+++ b/tfexec/workspace_select.go
@@ -11,5 +11,5 @@ import "context"
 func (tf *Tofu) WorkspaceSelect(ctx context.Context, workspace string) error {
 	// TODO: [DIR] param option
 
-	return tf.runTerraformCmd(ctx, tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
+	return tf.runTofuCmd(ctx, tf.buildTofuCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
 }

--- a/tfexec/workspace_show.go
+++ b/tfexec/workspace_show.go
@@ -22,7 +22,7 @@ func (tf *Tofu) WorkspaceShow(ctx context.Context) (string, error) {
 	var outBuffer strings.Builder
 	workspaceShowCmd.Stdout = &outBuffer
 
-	err = tf.runTerraformCmd(ctx, workspaceShowCmd)
+	err = tf.runTofuCmd(ctx, workspaceShowCmd)
 	if err != nil {
 		return "", err
 	}
@@ -36,5 +36,5 @@ func (tf *Tofu) workspaceShowCmd(ctx context.Context) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("workspace show was first introduced in Terraform 0.10.0: %w", err)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, "workspace", "show", "-no-color"), nil
+	return tf.buildTofuCmd(ctx, nil, "workspace", "show", "-no-color"), nil
 }

--- a/tfexec/workspace_show.go
+++ b/tfexec/workspace_show.go
@@ -13,7 +13,7 @@ import (
 )
 
 // WorkspaceShow represents the workspace show subcommand to the Terraform CLI.
-func (tf *Terraform) WorkspaceShow(ctx context.Context) (string, error) {
+func (tf *Tofu) WorkspaceShow(ctx context.Context) (string, error) {
 	workspaceShowCmd, err := tf.workspaceShowCmd(ctx)
 	if err != nil {
 		return "", err
@@ -30,7 +30,7 @@ func (tf *Terraform) WorkspaceShow(ctx context.Context) (string, error) {
 	return strings.TrimSpace(outBuffer.String()), nil
 }
 
-func (tf *Terraform) workspaceShowCmd(ctx context.Context) (*exec.Cmd, error) {
+func (tf *Tofu) workspaceShowCmd(ctx context.Context) (*exec.Cmd, error) {
 	err := tf.compatible(ctx, tf0_10_0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("workspace show was first introduced in Terraform 0.10.0: %w", err)

--- a/tfexec/workspace_show_test.go
+++ b/tfexec/workspace_show_test.go
@@ -15,7 +15,7 @@ import (
 func TestWorkspaceShowCmd_v1(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I've decided to separate this change from the other reference renaming, to make it dead simple for review.
This only changes the name of the main struct to Tofu and methods mentioning Terraform to Tofu.