### PR TITLE
Support for ShowModule - `tofu show -json -module=DIR`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,9 +132,9 @@ jobs:
           - ${{ needs.resolve-versions.outputs.oldstable }}
           - ${{ needs.resolve-versions.outputs.stable }}
         tofu_version:
-          - "1.8.11"
           - "1.9.3"
           - "1.10.5"
+          - "1.11.0-rc3"
     steps:
       -
         name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,9 +132,9 @@ jobs:
           - ${{ needs.resolve-versions.outputs.oldstable }}
           - ${{ needs.resolve-versions.outputs.stable }}
         tofu_version:
-          - "1.9.3"
-          - "1.10.5"
-          - "1.11.0-rc3"
+          - "1.9.4"
+          - "1.10.8"
+          - "1.11.1"
     steps:
       -
         name: Checkout

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -218,3 +218,64 @@ func TestShowBigInt(t *testing.T) {
 		}
 	})
 }
+
+// E2E test for ShowModule using deep_module testdata
+func TestShowModule_ShowModule(t *testing.T) {
+	runTest(t, "show_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
+		// Only run for OpenTofu version >= 1.11
+		minVer := version.Must(version.NewVersion("1.11.0-dev"))
+		if tfv.LessThan(minVer) {
+			t.Skip("ShowModule requires OpenTofu version >= 1.11.0")
+		}
+
+		// ShowModule for submodule1
+		mod, err := tf.ShowModule(context.Background(), "submodule1")
+		if err != nil {
+			t.Fatalf("ShowModule failed: %v", err)
+		}
+		if mod == nil {
+			t.Fatalf("ShowModule returned nil module")
+		}
+		if len(mod.Variables) != 2 {
+			t.Fatalf("expected 2 input variables, got %d", len(mod.Variables))
+		}
+		if len(mod.Outputs) != 1 {
+			t.Fatalf("expected 1 output, got %d", len(mod.Outputs))
+		}
+
+		// Submodule2
+		mod, err = tf.ShowModule(context.Background(), "submodule2")
+		if err != nil {
+			t.Fatalf("ShowModule failed: %v", err)
+		}
+		if mod == nil {
+			t.Fatalf("ShowModule returned nil module")
+		}
+		if len(mod.Variables) != 1 {
+			t.Fatalf("expected 1 input variables, got %d", len(mod.Variables))
+		}
+
+		if len(mod.ModuleCalls) != 1 {
+			t.Fatalf("expected 1 nested submodule, got %d", len(mod.ModuleCalls))
+		}
+
+		// Submodule21 with 2 outputs and 2 inputs
+		mod, err = tf.ShowModule(context.Background(), "submodule2/submodule21")
+		if err != nil {
+			t.Fatalf("ShowModule failed: %v", err)
+		}
+		if mod == nil {
+			t.Fatalf("ShowModule returned nil module")
+		}
+		if len(mod.Variables) != 2 {
+			t.Fatalf("expected 2 input variables, got %d", len(mod.Variables))
+		}
+		if len(mod.Outputs) != 2 {
+			t.Fatalf("expected 1 nested submodule, got %d", len(mod.ModuleCalls))
+		}
+		if len(mod.ModuleCalls) != 0 {
+			t.Fatalf("expected 0 nested submodule, got %d", len(mod.ModuleCalls))
+		}
+
+	})
+}

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -223,7 +223,7 @@ func TestShowBigInt(t *testing.T) {
 func TestShowModule_ShowModule(t *testing.T) {
 	runTest(t, "show_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Tofu) {
 		// Only run for OpenTofu version >= 1.11
-		minVer := version.Must(version.NewVersion("1.11.0-dev"))
+		minVer := version.Must(version.NewVersion("1.11.0-beta1"))
 		if tfv.LessThan(minVer) {
 			t.Skip("ShowModule requires OpenTofu version >= 1.11.0")
 		}

--- a/tfexec/internal/e2etest/testdata/show_module/main.tf
+++ b/tfexec/internal/e2etest/testdata/show_module/main.tf
@@ -1,0 +1,15 @@
+# Copyright (c) The OpenTofu Authors
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2023 HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+module "mod1" {
+  source = "./submodule1"
+  submodule1_var1 = "s1v1"
+  submodule1_var2 = "s1v2"
+}
+
+module "mod2" {
+  source = "./submodule2"
+  submodule2_var1 = "s2v1"
+}

--- a/tfexec/internal/e2etest/testdata/show_module/submodule1/main.tf
+++ b/tfexec/internal/e2etest/testdata/show_module/submodule1/main.tf
@@ -1,0 +1,16 @@
+# Copyright (c) The OpenTofu Authors
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2023 HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "submodule1_var1" {
+  type = string
+}
+
+variable "submodule1_var2" {
+  type = string
+}
+
+output "submodule1_out" {
+  value = concat(var.submodule1_var1, var.submodule1_var2)
+}

--- a/tfexec/internal/e2etest/testdata/show_module/submodule2/main.tf
+++ b/tfexec/internal/e2etest/testdata/show_module/submodule2/main.tf
@@ -1,0 +1,14 @@
+# Copyright (c) The OpenTofu Authors
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2023 HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+module "submodule21" {
+  source = "./submodule21"
+  submodule21_var1 = var.submodule2_var1
+  submodule21_var2 = "s21v2"
+}
+
+variable "submodule2_var1" {
+  type = string
+}

--- a/tfexec/internal/e2etest/testdata/show_module/submodule2/submodule21/main.tf
+++ b/tfexec/internal/e2etest/testdata/show_module/submodule2/submodule21/main.tf
@@ -1,0 +1,22 @@
+# Copyright (c) The OpenTofu Authors
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2023 HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "submodule21_var1" {
+  type = string
+}
+
+variable "submodule21_var2" {
+  type = string
+}
+
+
+
+output "submodule21_out1" {
+  value = var.submodule21_var1
+}
+
+output "submodule21_out2" {
+  value = var.submodule21_var2
+}

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -28,6 +28,7 @@ func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *
 	t.Helper()
 
 	versions := []string{
+		testutil.Latest_v1_11,
 		testutil.Latest_v1,
 		testutil.Latest_v1_9,
 		testutil.Latest_v1_8,

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -23,6 +23,7 @@ const (
 	Latest_v1_8  = "1.8.11"
 	Latest_v1_9  = "1.9.3"
 	Latest_v1_10 = "1.10.5"
+	Latest_v1_11 = "1.11.0-dev"
 	Latest_v1    = Latest_v1_10
 )
 
@@ -40,6 +41,7 @@ func NewTFCache(dir string) *TFCache {
 	}
 }
 
+// Version returns tofu executable path. If the desired version is not installed, it will be downloaded it in tf.dir location.
 func (tf *TFCache) Version(t *testing.T, v string) string {
 	t.Helper()
 

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -23,7 +23,7 @@ const (
 	Latest_v1_8  = "1.8.11"
 	Latest_v1_9  = "1.9.3"
 	Latest_v1_10 = "1.10.5"
-	Latest_v1_11 = "1.11.0-dev"
+	Latest_v1_11 = "1.11.0-rc3"
 	Latest_v1    = Latest_v1_10
 )
 

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -23,7 +23,7 @@ const (
 	Latest_v1_8  = "1.8.11"
 	Latest_v1_9  = "1.9.3"
 	Latest_v1_10 = "1.10.5"
-	Latest_v1_11 = "1.11.0-rc3"
+	Latest_v1_11 = "1.11.1"
 	Latest_v1    = Latest_v1_10
 )
 

--- a/tfexec/internal/testutil/tfcache_find.go
+++ b/tfexec/internal/testutil/tfcache_find.go
@@ -9,8 +9,31 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 )
+
+func getInstalledTofuIfVersionsMatch(v string) (string, error) {
+	// v will likely have a prefix tofu-
+	v = strings.TrimPrefix(v, "tofu-")
+	// Check a currently installed tofu version first
+	tofuPath, err := exec.LookPath("tofu")
+	if err != nil {
+		return "", err
+	}
+	// We run tofu -v here to check if the version matches the desired one
+	out, err := exec.CommandContext(context.Background(), tofuPath, "-v").Output()
+	if err != nil {
+		return "", err
+	}
+
+	if strings.Contains(string(out), v) {
+		return tofuPath, nil
+	}
+
+	return "", fmt.Errorf("installed version: %s", string(out))
+}
 
 func (tf *TFCache) find(t *testing.T, key string, execPathFunc func(context.Context) (string, error)) string {
 	t.Helper()
@@ -33,6 +56,12 @@ func (tf *TFCache) find(t *testing.T, key string, execPathFunc func(context.Cont
 	if err != nil {
 		// panic instead of t.fatal as this is going to affect all downstream tests reusing the cache entry
 		panic(fmt.Sprintf("unable to mkdir %q: %s", tf.dir, err))
+	}
+
+	// Try to find it locally
+	if path, err := getInstalledTofuIfVersionsMatch(key); err == nil {
+		tf.execs[key] = path
+		return path
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -178,7 +178,8 @@ func (tf *Tofu) ShowPlanFileRaw(ctx context.Context, planPath string, opts ...Sh
 // ShowModule returns module config based on moduleDir located in local filesystem.
 // This command was added in tofu version 1.11
 func (tf *Tofu) ShowModule(ctx context.Context, moduleDir string) (*Module, error) {
-	err := tf.compatible(ctx, version.Must(version.NewVersion("1.11.0-dev")), nil)
+	// tf.compatible check with stripped pre-release parts, so any 1.11 release will work including betas and rcs
+	err := tf.compatible(ctx, version.Must(version.NewVersion("1.11.0")), nil)
 	if err != nil {
 		return nil, fmt.Errorf("`tofu show -json -module=DIR` was added in tofu 1.11.0: %w", err)
 	}

--- a/tfexec/show_module_types.go
+++ b/tfexec/show_module_types.go
@@ -1,0 +1,92 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// This file is essentially a copy of the following in the opentofu core codebase.
+// https://github.com/opentofu/opentofu/blob/28493bc63f83aaa5fb2ff5063f050d80f9c51f4f/internal/command/jsonconfig/config.go
+// 2 things are modified.
+// - Types are exported, since this is intended to be public API.
+// - And expressions are removed, since those aren't marshaled during module config generation
+
+package tfexec
+
+import "encoding/json"
+
+type ModuleRoot struct {
+	Module Module `json:"root_module"`
+}
+type Module struct {
+	Outputs map[string]Output `json:"outputs,omitempty"`
+	// Resources are sorted in a user-friendly order that is undefined at this
+	// time, but consistent.
+	Resources   []Resource            `json:"resources,omitempty"`
+	ModuleCalls map[string]ModuleCall `json:"module_calls,omitempty"`
+	Variables   Variables             `json:"variables,omitempty"`
+}
+
+type ModuleCall struct {
+	Source            string   `json:"source,omitempty"`
+	Module            *Module  `json:"module,omitempty"`
+	VersionConstraint string   `json:"version_constraint,omitempty"`
+	DependsOn         []string `json:"depends_on,omitempty"`
+}
+
+// Variables is the json representation of the Variables provided to the current
+// plan.
+type Variables map[string]*Variable
+
+type Variable struct {
+	Type        json.RawMessage `json:"type,omitempty"`
+	Default     json.RawMessage `json:"default,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Required    bool            `json:"required,omitempty"`
+	Sensitive   bool            `json:"sensitive,omitempty"`
+	Deprecated  string          `json:"deprecated,omitempty"`
+}
+
+// Resource is the representation of a Resource in the config
+type Resource struct {
+	// Address is the absolute resource address
+	Address string `json:"address,omitempty"`
+
+	// Mode can be "managed" or "data"
+	Mode string `json:"mode,omitempty"`
+
+	Type string `json:"type,omitempty"`
+	Name string `json:"name,omitempty"`
+
+	// ProviderConfigKey is the key into "provider_configs" (shown above) for
+	// the provider configuration that this resource is associated with.
+	//
+	// NOTE: If a given resource is in a ModuleCall, and the provider was
+	// configured outside of the module (in a higher level configuration file),
+	// the ProviderConfigKey will not match a key in the ProviderConfigs map.
+	ProviderConfigKey string `json:"provider_config_key,omitempty"`
+
+	// Provisioners is an optional field which describes any provisioners.
+	// Connection info will not be included here.
+	Provisioners []Provisioner `json:"provisioners,omitempty"`
+
+	// Expressions" describes the resource-type-specific  content of the
+	// configuration block.
+	Expressions map[string]any `json:"expressions,omitempty"`
+
+	// SchemaVersion indicates which version of the resource type schema the
+	// "values" property conforms to.
+	SchemaVersion *uint64 `json:"schema_version,omitempty"`
+
+	DependsOn []string `json:"depends_on,omitempty"`
+}
+
+type Provisioner struct {
+	Type        string         `json:"type,omitempty"`
+	Expressions map[string]any `json:"expressions,omitempty"`
+}
+
+type Output struct {
+	Sensitive   bool     `json:"sensitive,omitempty"`
+	Deprecated  string   `json:"deprecated,omitempty"`
+	DependsOn   []string `json:"depends_on,omitempty"`
+	Description string   `json:"description,omitempty"`
+}

--- a/tfexec/show_test.go
+++ b/tfexec/show_test.go
@@ -21,7 +21,7 @@ func TestShowCmd(t *testing.T) {
 	}
 
 	// empty env, to avoid environ mismatch in testing
-	tf.SetEnv(map[string]string{})
+	_ = tf.SetEnv(map[string]string{})
 
 	// defaults
 	showCmd := tf.showCmd(context.Background(), true, nil)
@@ -42,7 +42,7 @@ func TestShowStateFileCmd(t *testing.T) {
 	}
 
 	// empty env, to avoid environ mismatch in testing
-	tf.SetEnv(map[string]string{})
+	_ = tf.SetEnv(map[string]string{})
 
 	showCmd := tf.showCmd(context.Background(), true, nil, "statefilepath")
 
@@ -54,6 +54,53 @@ func TestShowStateFileCmd(t *testing.T) {
 	}, nil, showCmd)
 }
 
+func TestShowModule_unsupportedTofuVersion(t *testing.T) {
+	tf, err := NewTofu(t.TempDir(), tfVersion(t, testutil.Latest_v1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = tf.SetEnv(map[string]string{})
+
+	_, err = tf.ShowModule(context.Background(), "foo/bar")
+	if err == nil {
+		t.Fatalf("expected error for unsupported version, got nil")
+	}
+}
+
+func TestShowModuleCmd(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1_11))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = tf.SetEnv(map[string]string{})
+
+	showCmd := tf.showCmd(context.Background(), true, nil, "-module=foo/bar")
+	assertCmd(t, []string{
+		"show",
+		"-json",
+		"-no-color",
+		"-module=foo/bar",
+	}, nil, showCmd)
+}
+
+func TestShowModule_blankDir(t *testing.T) {
+	td := t.TempDir()
+	tf, err := NewTofu(td, tfVersion(t, testutil.Latest_v1_11))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.SetEnv(map[string]string{})
+
+	_, err = tf.ShowModule(context.Background(), "")
+	if err == nil {
+		t.Fatalf("expected error for blank moduleDir, got nil")
+	}
+}
+
 func TestShowPlanFileCmd(t *testing.T) {
 	td := t.TempDir()
 
@@ -63,7 +110,7 @@ func TestShowPlanFileCmd(t *testing.T) {
 	}
 
 	// empty env, to avoid environ mismatch in testing
-	tf.SetEnv(map[string]string{})
+	_ = tf.SetEnv(map[string]string{})
 
 	showCmd := tf.showCmd(context.Background(), true, nil, "planfilepath")
 
@@ -84,7 +131,7 @@ func TestShowPlanFileRawCmd(t *testing.T) {
 	}
 
 	// empty env, to avoid environ mismatch in testing
-	tf.SetEnv(map[string]string{})
+	_ = tf.SetEnv(map[string]string{})
 
 	showCmd := tf.showCmd(context.Background(), false, nil, "planfilepath")
 

--- a/tfexec/version_test.go
+++ b/tfexec/version_test.go
@@ -76,6 +76,8 @@ func TestVersionInRange(t *testing.T) {
 		{true, "1.7.0", "1.7.0-beta3", "1.8.0"},
 		{true, "", "1.7.0-beta3", "1.8.0"},
 		{expected: true, min: "1.11.0-dev", tfv: "1.11.0", max: ""},
+		{expected: true, min: "1.11.0-rc1", tfv: "1.11.0", max: ""},
+		{expected: true, min: "1.11.0", tfv: "1.11.0-beta1", max: ""},
 		{expected: false, min: "1.11.0-dev", tfv: "1.10.0", max: ""},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
Adds support for `tofu show -json -module=DIR` in a method called `ShowModule`.
Read more [about it](https://github.com/opentofu/opentofu/pull/3003)

---

<s>This branch includes PR #8  as a base, and this needs to be merged after that. 
We should hold merging this PR until OpenTofu v1.11 is published—and update tests.yml to reflect the latest tofu version and refactor the mentions of `1.11.0-dev` before merging. I am marking this as blocked until both conditions are met.