### PR TITLE
Add opt-in graceful shutdown for tofu child processes

### DIFF
--- a/tfexec/cmd_linux_test.go
+++ b/tfexec/cmd_linux_test.go
@@ -8,7 +8,11 @@ package tfexec
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -38,4 +42,131 @@ func Test_runTofuCmd_linux(t *testing.T) {
 	if strings.Contains(buf.String(), "error from kill") {
 		t.Fatal("canceling context should not lead to logging an error")
 	}
+}
+
+func TestGracefulShutdown_linux(t *testing.T) {
+	td := t.TempDir()
+
+	// Shell script that traps SIGINT, touches a marker file, and exits.
+	// Uses background sleep + wait so the shell can process signals
+	// between iterations (wait is interruptible by signals, sleep is not).
+	script := filepath.Join(td, "trap.sh")
+	err := os.WriteFile(script, []byte(`#!/bin/sh
+trap 'touch "$1"; exit 0' INT
+while true; do sleep 0.1 & wait $!; done
+`), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("default kills immediately", func(t *testing.T) {
+		sigFile := filepath.Join(t.TempDir(), "got_sigint")
+
+		tf := &Tofu{
+			execPath:   script,
+			workingDir: td,
+			logger:     log.New(io.Discard, "", 0),
+		}
+		tf.SetEnv(map[string]string{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() {
+			cmd := tf.buildTofuCmd(ctx, nil, sigFile)
+			errCh <- tf.runTofuCmd(ctx, cmd)
+		}()
+
+		// Give the process time to start and set up the trap.
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+
+		err := <-errCh
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+
+		// Process was killed with SIGKILL — trap never ran, no file.
+		if _, err := os.Stat(sigFile); !os.IsNotExist(err) {
+			t.Fatal("expected process to be killed without receiving SIGINT")
+		}
+	})
+
+	t.Run("graceful sends SIGINT", func(t *testing.T) {
+		sigFile := filepath.Join(t.TempDir(), "got_sigint")
+
+		tf := &Tofu{
+			execPath:                script,
+			workingDir:              td,
+			logger:                  log.New(io.Discard, "", 0),
+			gracefulShutdownTimeout: 5 * time.Second,
+		}
+		tf.SetEnv(map[string]string{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() {
+			cmd := tf.buildTofuCmd(ctx, nil, sigFile)
+			errCh <- tf.runTofuCmd(ctx, cmd)
+		}()
+
+		// Give the process time to start and set up the trap.
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+
+		err := <-errCh
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+
+		// Process received SIGINT — trap ran and created the file.
+		if _, err := os.Stat(sigFile); err != nil {
+			t.Fatal("expected process to receive SIGINT for graceful shutdown")
+		}
+	})
+
+	t.Run("force kills after timeout", func(t *testing.T) {
+		// Script that traps SIGINT but refuses to exit — simulates a
+		// stuck process that ignores the graceful shutdown signal.
+		stubborn := filepath.Join(t.TempDir(), "stubborn.sh")
+		err := os.WriteFile(stubborn, []byte(`#!/bin/sh
+trap '' INT
+while true; do sleep 0.1 & wait $!; done
+`), 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tf := &Tofu{
+			execPath:                stubborn,
+			workingDir:              td,
+			logger:                  log.New(io.Discard, "", 0),
+			gracefulShutdownTimeout: 1 * time.Second,
+		}
+		tf.SetEnv(map[string]string{})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() {
+			cmd := tf.buildTofuCmd(ctx, nil)
+			errCh <- tf.runTofuCmd(ctx, cmd)
+		}()
+
+		// Give the process time to start.
+		time.Sleep(500 * time.Millisecond)
+
+		start := time.Now()
+		cancel()
+		<-errCh
+		elapsed := time.Since(start)
+
+		// WaitDelay is 1s. The process ignores SIGINT, so Go's exec
+		// machinery must SIGKILL it after the delay. Allow some slack
+		// but assert it didn't hang.
+		if elapsed > 3*time.Second {
+			t.Fatalf("expected process to be force-killed after WaitDelay, but took %s", elapsed)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- When context is cancelled, `exec.CommandContext` sends SIGKILL by default — tofu can't catch it and leaves backend state locks dangling
- Add `SetGracefulShutdown(timeout)` on the `Tofu` struct: sends `os.Interrupt` (SIGINT on Unix) via `cmd.Cancel`, giving tofu time to clean up (e.g. release state locks)
- After the timeout, Go's exec machinery force-kills via `cmd.WaitDelay`
- On Windows, where `os.Interrupt` is not supported, falls back to `Kill` immediately
- Default behavior (immediate kill) is fully preserved — opt-in only

## Test plan

- [x] Structural unit tests verify `buildTofuCmd` sets `Cancel`/`WaitDelay` when enabled and leaves defaults when not
- [x] Functional test: default behavior sends SIGKILL (trap never fires, no marker file)
- [x] Functional test: graceful shutdown sends SIGINT (trap fires, marker file created)
- [x] Functional test: stubborn process ignoring SIGINT is force-killed after `WaitDelay` (not hanging)
- [x] `go build ./...`, `go vet ./...`, `gofmt -s -l .` clean
- [x] `go test -race` passes (excluding e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)